### PR TITLE
Feature/add local driver

### DIFF
--- a/automation_extensions.gemspec
+++ b/automation_extensions.gemspec
@@ -28,6 +28,9 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "capybara", "~> 3.8"
+  spec.add_runtime_dependency "selenium-webdriver", [">= 4.0.0.alpha1", "< 4.1"]
+
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/automation_extensions.gemspec
+++ b/automation_extensions.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "selenium-webdriver", [">= 4.0.0.alpha1", "< 4.1"]
 
   spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rspec", "~> 3.8"
 end

--- a/lib/automation_extensions.rb
+++ b/lib/automation_extensions.rb
@@ -1,6 +1,3 @@
 # frozen_string_literal: true
 require "automation_extensions/drivers"
 require "automation_extensions/version"
-
-# {AutomationExtensions} namespace
-module AutomationExtensions; end

--- a/lib/automation_extensions/drivers.rb
+++ b/lib/automation_extensions/drivers.rb
@@ -1,8 +1,3 @@
 # frozen_string_literal: true
 require "automation_extensions/drivers/local"
 require "automation_extensions/drivers/v4"
-
-module AutomationExtensions
-  # {AutomationExtensions::Drivers} namespace
-  module Drivers; end
-end

--- a/lib/automation_extensions/drivers.rb
+++ b/lib/automation_extensions/drivers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 require "automation_extensions/drivers/local"
+require "automation_extensions/drivers/v4"
+
 
 module AutomationExtensions
   # {AutomationExtensions::Drivers} namespace

--- a/lib/automation_extensions/drivers.rb
+++ b/lib/automation_extensions/drivers.rb
@@ -2,7 +2,6 @@
 require "automation_extensions/drivers/local"
 require "automation_extensions/drivers/v4"
 
-
 module AutomationExtensions
   # {AutomationExtensions::Drivers} namespace
   module Drivers; end

--- a/lib/automation_extensions/drivers/local.rb
+++ b/lib/automation_extensions/drivers/local.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
+
+require "automation_extensions/drivers/v4/local"
+
 # {AutomationExtensions} namespace
 module AutomationExtensions
   module Drivers
     # The local driver configuration for running Capybara-wrapped Selenium
-    class Local
-      # TBD - Will be added as a first pass for v0.2
-    end
+    # By default we want to use the V4 local (But others may be supported)
+    Local = V4::Local
   end
 end

--- a/lib/automation_extensions/drivers/local.rb
+++ b/lib/automation_extensions/drivers/local.rb
@@ -2,11 +2,8 @@
 
 require "automation_extensions/drivers/v4/local"
 
-# {AutomationExtensions} namespace
 module AutomationExtensions
   module Drivers
-    # The local driver configuration for running Capybara-wrapped Selenium
-    # By default we want to use the V4 local (But others may be supported)
     Local = V4::Local
   end
 end

--- a/lib/automation_extensions/drivers/v4.rb
+++ b/lib/automation_extensions/drivers/v4.rb
@@ -1,0 +1,2 @@
+require "automation_extensions/drivers/v4/local"
+require "automation_extensions/drivers/v4/options"

--- a/lib/automation_extensions/drivers/v4.rb
+++ b/lib/automation_extensions/drivers/v4.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 require "automation_extensions/drivers/v4/local"
 require "automation_extensions/drivers/v4/options"

--- a/lib/automation_extensions/drivers/v4.rb
+++ b/lib/automation_extensions/drivers/v4.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+
 require "automation_extensions/drivers/v4/local"
 require "automation_extensions/drivers/v4/options"

--- a/lib/automation_extensions/drivers/v4/local.rb
+++ b/lib/automation_extensions/drivers/v4/local.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+module AutomationExtensions
+  module Drivers
+    # {AutomationExtensions::Drivers::V4} namespace
+    module V4
+      # The local driver configuration for running Capybara-wrapped Selenium
+      class Local
+        def initialize(browser)
+          @browser = browser
+        end
+
+        def create
+          Capybara.register_driver :selenium do |app|
+            Capybara::Selenium::Driver.new(
+              app,
+              browser: @browser,
+              service: service,
+              capabilities: [desired_capabilities, options]
+            )
+          end
+        end
+
+        private
+
+        # This is required to make local drivers work exclusively with Safari TP
+        # This is required in V13 of Safari as the driver there is notoriously flaky
+        # In V12 it doesn't hinder it
+        # We don't support Safari V11!
+        def service
+          return unless safari?
+
+          Selenium::WebDriver::Safari.technology_preview!
+          Selenium::WebDriver::Service.safari({ args: ["--diagnose"] })
+        end
+
+        def desired_capabilities
+          Selenium::WebDriver::Remote::Capabilities.new.tap do |capabilities|
+            if safari?
+              capabilities["browserName"] = "Safari Technology Preview"
+              AutomationLogger.debug("Altering Browser Name request to alleviate Capybara failure with STP.")
+            end
+          end
+        end
+
+        def safari?
+          @browser == :safari
+        end
+      end
+    end
+  end
+end
+
+
+#

--- a/lib/automation_extensions/drivers/v4/local.rb
+++ b/lib/automation_extensions/drivers/v4/local.rb
@@ -5,6 +5,9 @@ module AutomationExtensions
     module V4
       # The local driver configuration for running Capybara-wrapped Selenium
       class Local
+        attr_reader :browser
+        private :browser
+
         def initialize(browser)
           @browser = browser
         end
@@ -13,7 +16,7 @@ module AutomationExtensions
           Capybara.register_driver :selenium do |app|
             Capybara::Selenium::Driver.new(
               app,
-              browser: @browser,
+              browser: browser,
               service: service,
               capabilities: [desired_capabilities, options]
             )
@@ -33,6 +36,12 @@ module AutomationExtensions
           Selenium::WebDriver::Service.safari({ args: ["--diagnose"] })
         end
 
+        # This is required because Capybara and Safari aren't quite sure what the difference
+        # is between the two browsers. So to compensate an illegal browserName value is
+        # set that allows easy distinction between the two browsers
+        #
+        # NB: Whilst using Safari TP this is required. When not using Safari TP, this can
+        # be removed
         def desired_capabilities
           Selenium::WebDriver::Remote::Capabilities.new.tap do |capabilities|
             if safari?
@@ -43,12 +52,9 @@ module AutomationExtensions
         end
 
         def safari?
-          @browser == :safari
+          browser == :safari
         end
       end
     end
   end
 end
-
-
-#

--- a/lib/automation_extensions/drivers/v4/local.rb
+++ b/lib/automation_extensions/drivers/v4/local.rb
@@ -30,8 +30,8 @@ module AutomationExtensions
         def service
           return unless safari?
 
-          Selenium::WebDriver::Safari.technology_preview!
-          Selenium::WebDriver::Service.safari({ args: ["--diagnose"] })
+          ::Selenium::WebDriver::Safari.technology_preview!
+          ::Selenium::WebDriver::Service.safari({ args: ["--diagnose"] })
         end
 
         # This is required because Capybara and Safari aren't quite sure what the difference
@@ -41,10 +41,12 @@ module AutomationExtensions
         # NB: Whilst using Safari TP this is required. When not using Safari TP, this can
         # be removed
         def desired_capabilities
-          Selenium::WebDriver::Remote::Capabilities.new.tap do |capabilities|
+          ::Selenium::WebDriver::Remote::Capabilities.new.tap do |capabilities|
             if safari?
               capabilities["browserName"] = "Safari Technology Preview"
-              AutomationLogger.debug("Altering Browser Name request to alleviate Capybara failure with STP.")
+              # TOFIX: Implement logger
+              # AutomationLogger.debug("Altering Browser Name request to alleviate Capybara failure with STP.")
+              warn "Altering Browser Name request to alleviate Capybara failure with STP."
             end
           end
         end

--- a/lib/automation_extensions/drivers/v4/local.rb
+++ b/lib/automation_extensions/drivers/v4/local.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 module AutomationExtensions
   module Drivers
-    # {AutomationExtensions::Drivers::V4} namespace
     module V4
-      # The local driver configuration for running Capybara-wrapped Selenium
       class Local
         attr_reader :browser
         private :browser

--- a/lib/automation_extensions/drivers/v4/local.rb
+++ b/lib/automation_extensions/drivers/v4/local.rb
@@ -51,6 +51,10 @@ module AutomationExtensions
           end
         end
 
+        def options
+          Options.new(browser).options
+        end
+
         def safari?
           browser == :safari
         end

--- a/lib/automation_extensions/drivers/v4/local.rb
+++ b/lib/automation_extensions/drivers/v4/local.rb
@@ -10,7 +10,7 @@ module AutomationExtensions
           @browser = browser
         end
 
-        def create
+        def register
           Capybara.register_driver :selenium do |app|
             Capybara::Selenium::Driver.new(
               app,

--- a/lib/automation_extensions/drivers/v4/options.rb
+++ b/lib/automation_extensions/drivers/v4/options.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module AutomationExtensions
+  module Drivers
+    module V4
+      class Options
+        attr_reader :browser
+        private :browser
+
+        def initialize(browser)
+          @browser = browser
+        end
+
+        def options
+          send("#{browser}_options").tap { |opts| opts.headless! if headless? }
+        end
+
+        private
+
+        def chrome_options
+          Selenium::WebDriver::Chrome::Options.new
+        end
+
+        # Constantly fire mouseOver events on click actions (Should help mitigate flaky clicks)
+        def internet_explorer_options
+          Selenium::WebDriver::IE::Options.new(persistent_hover: true).tap do |opts|
+            # This is needed to mitigate a Selenium4/Browserstack issue whereby in Se4
+            # we combine Browser options and Capabilities and merge them. But for some
+            # reason Browserstack insist on giving `internet_explorer` a non-conformant
+            # name `IE`. This then causes huge issues in trying to find a browser that
+            # would match using firstMatch in 2 different ways.
+            #
+            # A Support ticket has been raised with Browserstack to see if they can fix
+            # anything at their end, as this is a bug with their matching protocols
+            # LH - Aug 2020
+            AutomationLogger.warn("Removing `browser_name` key from options payload.")
+            opts.options.delete(:browser_name)
+          end
+        end
+
+        def firefox_options
+          Selenium::WebDriver::Firefox::Options.new(log_level: "info")
+        end
+
+        def edge_options
+          Selenium::WebDriver::Edge::Options.new
+        end
+
+        # Preload Web Inspector and JavaScript debugger
+        def safari_options
+          Selenium::WebDriver::Safari::Options.new(automatic_inspection: true)
+        end
+
+        def android_options
+          {}
+        end
+
+        def ios_options
+          {}
+        end
+
+        def headless?
+          ENV["HEADLESS"] == "true"
+        end
+      end
+    end
+  end
+end

--- a/lib/automation_extensions/drivers/v4/options.rb
+++ b/lib/automation_extensions/drivers/v4/options.rb
@@ -18,12 +18,12 @@ module AutomationExtensions
         private
 
         def chrome_options
-          Selenium::WebDriver::Chrome::Options.new
+          ::Selenium::WebDriver::Chrome::Options.new
         end
 
         # Constantly fire mouseOver events on click actions (Should help mitigate flaky clicks)
         def internet_explorer_options
-          Selenium::WebDriver::IE::Options.new(persistent_hover: true).tap do |opts|
+          ::Selenium::WebDriver::IE::Options.new(persistent_hover: true).tap do |opts|
             # This is needed to mitigate a Selenium4/Browserstack issue whereby in Se4
             # we combine Browser options and Capabilities and merge them. But for some
             # reason Browserstack insist on giving `internet_explorer` a non-conformant
@@ -33,22 +33,26 @@ module AutomationExtensions
             # A Support ticket has been raised with Browserstack to see if they can fix
             # anything at their end, as this is a bug with their matching protocols
             # LH - Aug 2020
-            AutomationLogger.warn("Removing `browser_name` key from options payload.")
+
+            # TOFIX: Implement logger
+            # AutomationLogger.warn("Removing `browser_name` key from options payload.")
+            puts("Removing `browser_name` key from options payload.")
+
             opts.options.delete(:browser_name)
           end
         end
 
         def firefox_options
-          Selenium::WebDriver::Firefox::Options.new(log_level: "info")
+          ::Selenium::WebDriver::Firefox::Options.new(log_level: "info")
         end
 
         def edge_options
-          Selenium::WebDriver::Edge::Options.new
+          ::Selenium::WebDriver::Edge::Options.new
         end
 
         # Preload Web Inspector and JavaScript debugger
         def safari_options
-          Selenium::WebDriver::Safari::Options.new(automatic_inspection: true)
+          ::Selenium::WebDriver::Safari::Options.new(automatic_inspection: true)
         end
 
         def android_options

--- a/spec/automation_extensions/drivers/local_spec.rb
+++ b/spec/automation_extensions/drivers/local_spec.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 RSpec.describe AutomationExtensions::Drivers::Local do
-  it { is_expected.to be_a AutomationExtensions::Drivers::Local }
+  it "Aliases the shorter context to the V4 namespace" do
+    expect(described_class.new(double)).to be_a(AutomationExtensions::Drivers::V4::Local)
+  end
 end

--- a/spec/automation_extensions/drivers/v4/local_spec.rb
+++ b/spec/automation_extensions/drivers/v4/local_spec.rb
@@ -1,28 +1,27 @@
 # frozen_string_literal: true
 RSpec.describe AutomationExtensions::Drivers::V4::Local do
-  let(:local_driver_class) { described_class.new(browser) }
-  let(:current_driver) { Capybara.current_session.driver }
-
   before { Capybara.default_driver = :selenium }
-  before { local_driver_class.register }
 
   describe "#register" do
     context "for chrome" do
+      before { described_class.new(browser).register }
+  
+      let(:session) { Capybara::Session.new(:selenium) }
       let(:browser) { :chrome }
       
       it "has correct top level properties" do
-        expect(current_driver.options.keys)
+        expect(session.driver.options.keys)
           .to eq(
             %i[browser clear_local_storage clear_session_storage service capabilities]
           )
       end
 
       it "has correct desired capabilities" do
-        expect(current_driver.options[:capabilities].first.as_json).to eq({})
+        expect(session.driver.options[:capabilities].first.as_json).to eq({})
       end
 
       it "has correct browser options" do
-        expect(current_driver.options[:capabilities].last.as_json)
+        expect(session.driver.options[:capabilities].last.as_json)
           .to eq(
             {
               "browserName" => "chrome",
@@ -33,25 +32,28 @@ RSpec.describe AutomationExtensions::Drivers::V4::Local do
     end
 
     context "for firefox" do
+      before { described_class.new(browser).register }
+  
+      let(:session) { Capybara::Session.new(:selenium) }
       let(:browser) { :firefox }
 
       it "has correct top level properties" do
-        expect(current_driver.options.keys)
+        expect(session.driver.options.keys)
           .to eq(
             %i[browser clear_local_storage clear_session_storage service capabilities]
           )
       end
 
       it "has correct desired capabilities" do
-        expect(current_driver.options[:capabilities].first.as_json).to eq({})
+        expect(session.driver.options[:capabilities].first.as_json).to eq({})
       end
 
       it "has correct browser options" do
-        expect(current_driver.options[:capabilities].last.as_json)
+        expect(session.driver.options[:capabilities].last.as_json)
           .to eq(
             {
-              "browserName" => "chrome",
-              "goog:chromeOptions" => {}
+              "browserName" => "firefox",
+              "moz:firefoxOptions"=>{"log"=>{"level"=>"info"}}
             }
           )
       end
@@ -76,12 +78,10 @@ RSpec.describe AutomationExtensions::Drivers::V4::Local do
           .to eq(
             {
               "browserName" => "chrome",
-              "goog:chromeOptions" => {}
+              "se:ieOptions"=>{"enablePersistentHover"=>true, "nativeEvents"=>true}
             }
           )
       end
-
-      it { is_expected.to have_attributes({ native_events: true, persistent_hover: true }) }
     end
 
     context "for safari" do
@@ -107,8 +107,6 @@ RSpec.describe AutomationExtensions::Drivers::V4::Local do
             }
           )
       end
-
-      it { is_expected.to have_attributes({ browser_name: "safari", automatic_inspection: true }) }
     end
 
     context "for ios" do

--- a/spec/automation_extensions/drivers/v4/local_spec.rb
+++ b/spec/automation_extensions/drivers/v4/local_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+RSpec.describe AutomationExtensions::Drivers::V4::Local do
+  let(:local_driver_class) { described_class.new(browser) }
+  let(:current_driver) { Capybara.current_session.driver }
+
+  before { Capybara.default_driver = :selenium }
+  before { local_driver_class.register }
+
+  describe "#register" do
+    context "for chrome" do
+      let(:browser) { :chrome }
+      
+      it "has correct top level properties" do
+        expect(current_driver.options.keys)
+          .to eq(
+            %i[browser clear_local_storage clear_session_storage service capabilities]
+          )
+      end
+
+      it "has correct desired capabilities" do
+        expect(current_driver.options[:capabilities].first.as_json).to eq({})
+      end
+
+      it "has correct browser options" do
+        expect(current_driver.options[:capabilities].last.as_json)
+          .to eq(
+            {
+              "browserName" => "chrome",
+              "goog:chromeOptions" => {}
+            }
+          )
+      end
+    end
+
+    context "for firefox" do
+      let(:browser) { :firefox }
+
+      it "has correct top level properties" do
+        expect(current_driver.options.keys)
+          .to eq(
+            %i[browser clear_local_storage clear_session_storage service capabilities]
+          )
+      end
+
+      it "has correct desired capabilities" do
+        expect(current_driver.options[:capabilities].first.as_json).to eq({})
+      end
+
+      it "has correct browser options" do
+        expect(current_driver.options[:capabilities].last.as_json)
+          .to eq(
+            {
+              "browserName" => "chrome",
+              "goog:chromeOptions" => {}
+            }
+          )
+      end
+    end
+
+    context "for internet explorer" do
+      let(:browser) { :internet_explorer }
+
+      it "has correct top level properties" do
+        expect(current_driver.options.keys)
+          .to eq(
+            %i[browser clear_local_storage clear_session_storage service capabilities]
+          )
+      end
+
+      it "has correct desired capabilities" do
+        expect(current_driver.options[:capabilities].first.as_json).to eq({})
+      end
+
+      it "has correct browser options" do
+        expect(current_driver.options[:capabilities].last.as_json)
+          .to eq(
+            {
+              "browserName" => "chrome",
+              "goog:chromeOptions" => {}
+            }
+          )
+      end
+
+      it { is_expected.to have_attributes({ native_events: true, persistent_hover: true }) }
+    end
+
+    context "for safari" do
+      let(:browser) { :safari }
+
+      it "has correct top level properties" do
+        expect(current_driver.options.keys)
+          .to eq(
+            %i[browser clear_local_storage clear_session_storage service capabilities]
+          )
+      end
+
+      it "has correct desired capabilities" do
+        expect(current_driver.options[:capabilities].first.as_json).to eq({})
+      end
+
+      it "has correct browser options" do
+        expect(current_driver.options[:capabilities].last.as_json)
+          .to eq(
+            {
+              "browserName" => "chrome",
+              "goog:chromeOptions" => {}
+            }
+          )
+      end
+
+      it { is_expected.to have_attributes({ browser_name: "safari", automatic_inspection: true }) }
+    end
+
+    context "for ios" do
+      let(:browser) { :ios }
+
+      it "has correct top level properties" do
+        expect(current_driver.options.keys)
+          .to eq(
+            %i[browser clear_local_storage clear_session_storage service capabilities]
+          )
+      end
+
+      it "has correct desired capabilities" do
+        expect(current_driver.options[:capabilities].first.as_json).to eq({})
+      end
+
+      it "has correct browser options" do
+        expect(current_driver.options[:capabilities].last.as_json)
+          .to eq(
+            {
+              "browserName" => "chrome",
+              "goog:chromeOptions" => {}
+            }
+          )
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context "for android" do
+      let(:browser) { :android }
+
+      it "has correct top level properties" do
+        expect(current_driver.options.keys)
+          .to eq(
+            %i[browser clear_local_storage clear_session_storage service capabilities]
+          )
+      end
+
+      it "has correct desired capabilities" do
+        expect(current_driver.options[:capabilities].first.as_json).to eq({})
+      end
+
+      it "has correct browser options" do
+        expect(current_driver.options[:capabilities].last.as_json)
+          .to eq(
+            {
+              "browserName" => "chrome",
+              "goog:chromeOptions" => {}
+            }
+          )
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context "for an unsupported browser" do
+      let(:browser) { :foo }
+
+      it "Doesn't work if the browser is not one of the supported browsers" do
+        expect { current_driver.options }.to raise_error(NoMethodError)
+      end
+    end
+  end
+end

--- a/spec/automation_extensions/drivers/v4/local_spec.rb
+++ b/spec/automation_extensions/drivers/v4/local_spec.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 RSpec.describe AutomationExtensions::Drivers::V4::Local do
-  before { Capybara.default_driver = :selenium }
+  before do
+    Capybara.default_driver = :selenium
+    described_class.new(browser).register
+  end
+
+  let(:session) { Capybara::Session.new(:selenium) }
 
   describe "#register" do
     context "for chrome" do
-      before { described_class.new(browser).register }
-  
-      let(:session) { Capybara::Session.new(:selenium) }
       let(:browser) { :chrome }
-      
+
       it "has correct top level properties" do
         expect(session.driver.options.keys)
           .to eq(
@@ -32,9 +34,6 @@ RSpec.describe AutomationExtensions::Drivers::V4::Local do
     end
 
     context "for firefox" do
-      before { described_class.new(browser).register }
-  
-      let(:session) { Capybara::Session.new(:selenium) }
       let(:browser) { :firefox }
 
       it "has correct top level properties" do
@@ -53,7 +52,7 @@ RSpec.describe AutomationExtensions::Drivers::V4::Local do
           .to eq(
             {
               "browserName" => "firefox",
-              "moz:firefoxOptions"=>{"log"=>{"level"=>"info"}}
+              "moz:firefoxOptions" => { "log" => { "level" => "info" } }
             }
           )
       end
@@ -61,24 +60,24 @@ RSpec.describe AutomationExtensions::Drivers::V4::Local do
 
     context "for internet explorer" do
       let(:browser) { :internet_explorer }
+      let(:options) { session.driver.options }
 
       it "has correct top level properties" do
-        expect(current_driver.options.keys)
+        expect(options.keys)
           .to eq(
             %i[browser clear_local_storage clear_session_storage service capabilities]
           )
       end
 
       it "has correct desired capabilities" do
-        expect(current_driver.options[:capabilities].first.as_json).to eq({})
+        expect(options[:capabilities].first.as_json).to eq({})
       end
 
-      it "has correct browser options" do
-        expect(current_driver.options[:capabilities].last.as_json)
+      it "has correct (Modified), browser options" do
+        expect(options[:capabilities].last.as_json)
           .to eq(
             {
-              "browserName" => "chrome",
-              "se:ieOptions"=>{"enablePersistentHover"=>true, "nativeEvents"=>true}
+              "se:ieOptions" => { "enablePersistentHover" => true, "nativeEvents" => true }
             }
           )
       end

--- a/spec/automation_extensions/drivers/v4/local_spec.rb
+++ b/spec/automation_extensions/drivers/v4/local_spec.rb
@@ -6,24 +6,22 @@ RSpec.describe AutomationExtensions::Drivers::V4::Local do
   end
 
   let(:session) { Capybara::Session.new(:selenium) }
+  let(:options) { session.driver.options }
 
   describe "#register" do
     context "for chrome" do
       let(:browser) { :chrome }
 
       it "has correct top level properties" do
-        expect(session.driver.options.keys)
-          .to eq(
-            %i[browser clear_local_storage clear_session_storage service capabilities]
-          )
+        expect(options.keys).to eq(%i[browser clear_local_storage clear_session_storage service capabilities])
       end
 
       it "has correct desired capabilities" do
-        expect(session.driver.options[:capabilities].first.as_json).to eq({})
+        expect(options[:capabilities].first.as_json).to eq({})
       end
 
       it "has correct browser options" do
-        expect(session.driver.options[:capabilities].last.as_json)
+        expect(options[:capabilities].last.as_json)
           .to eq(
             {
               "browserName" => "chrome",
@@ -37,18 +35,15 @@ RSpec.describe AutomationExtensions::Drivers::V4::Local do
       let(:browser) { :firefox }
 
       it "has correct top level properties" do
-        expect(session.driver.options.keys)
-          .to eq(
-            %i[browser clear_local_storage clear_session_storage service capabilities]
-          )
+        expect(options.keys).to eq(%i[browser clear_local_storage clear_session_storage service capabilities])
       end
 
       it "has correct desired capabilities" do
-        expect(session.driver.options[:capabilities].first.as_json).to eq({})
+        expect(options[:capabilities].first.as_json).to eq({})
       end
 
       it "has correct browser options" do
-        expect(session.driver.options[:capabilities].last.as_json)
+        expect(options[:capabilities].last.as_json)
           .to eq(
             {
               "browserName" => "firefox",
@@ -60,13 +55,9 @@ RSpec.describe AutomationExtensions::Drivers::V4::Local do
 
     context "for internet explorer" do
       let(:browser) { :internet_explorer }
-      let(:options) { session.driver.options }
 
       it "has correct top level properties" do
-        expect(options.keys)
-          .to eq(
-            %i[browser clear_local_storage clear_session_storage service capabilities]
-          )
+        expect(options.keys).to eq(%i[browser clear_local_storage clear_session_storage service capabilities])
       end
 
       it "has correct desired capabilities" do
@@ -83,90 +74,11 @@ RSpec.describe AutomationExtensions::Drivers::V4::Local do
       end
     end
 
-    context "for safari" do
-      let(:browser) { :safari }
-
-      it "has correct top level properties" do
-        expect(current_driver.options.keys)
-          .to eq(
-            %i[browser clear_local_storage clear_session_storage service capabilities]
-          )
-      end
-
-      it "has correct desired capabilities" do
-        expect(current_driver.options[:capabilities].first.as_json).to eq({})
-      end
-
-      it "has correct browser options" do
-        expect(current_driver.options[:capabilities].last.as_json)
-          .to eq(
-            {
-              "browserName" => "chrome",
-              "goog:chromeOptions" => {}
-            }
-          )
-      end
-    end
-
-    context "for ios" do
-      let(:browser) { :ios }
-
-      it "has correct top level properties" do
-        expect(current_driver.options.keys)
-          .to eq(
-            %i[browser clear_local_storage clear_session_storage service capabilities]
-          )
-      end
-
-      it "has correct desired capabilities" do
-        expect(current_driver.options[:capabilities].first.as_json).to eq({})
-      end
-
-      it "has correct browser options" do
-        expect(current_driver.options[:capabilities].last.as_json)
-          .to eq(
-            {
-              "browserName" => "chrome",
-              "goog:chromeOptions" => {}
-            }
-          )
-      end
-
-      it { is_expected.to be_empty }
-    end
-
-    context "for android" do
-      let(:browser) { :android }
-
-      it "has correct top level properties" do
-        expect(current_driver.options.keys)
-          .to eq(
-            %i[browser clear_local_storage clear_session_storage service capabilities]
-          )
-      end
-
-      it "has correct desired capabilities" do
-        expect(current_driver.options[:capabilities].first.as_json).to eq({})
-      end
-
-      it "has correct browser options" do
-        expect(current_driver.options[:capabilities].last.as_json)
-          .to eq(
-            {
-              "browserName" => "chrome",
-              "goog:chromeOptions" => {}
-            }
-          )
-      end
-
-      it { is_expected.to be_empty }
-    end
-
     context "for an unsupported browser" do
       let(:browser) { :foo }
 
       it "Doesn't work if the browser is not one of the supported browsers" do
-        expect { current_driver.options }.to raise_error(NoMethodError)
+        expect { options }.to raise_error(NoMethodError)
       end
     end
   end

--- a/spec/automation_extensions/drivers/v4/options_spec.rb
+++ b/spec/automation_extensions/drivers/v4/options_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+RSpec.describe AutomationExtensions::Drivers::V4::Options do
+  describe "#options" do
+    subject { described_class.new(browser).options }
+
+    context "for chrome" do
+      let(:browser) { :chrome }
+
+      it "returns the correct v4 compliant options" do
+        expect(subject).to eq({})
+      end
+    end
+
+    context "for firefox" do
+      let(:browser) { :firefox }
+
+      it "returns the correct v4 compliant options" do
+        expect(subject).to eq({})
+      end
+    end
+
+    context "for internet explorer" do
+      let(:browser) { :internet_explorer }
+
+      it "returns the correct v4 compliant options" do
+        expect(subject).to eq({})
+      end
+    end
+
+    context "for safari" do
+      let(:browser) { :safari }
+
+      it "returns the correct v4 compliant options" do
+        expect(subject).to eq({})
+      end
+    end
+
+    context "for ios" do
+      let(:browser) { :ios }
+
+      it "returns the correct v4 compliant options" do
+        expect(subject).to eq({})
+      end
+    end
+  end
+end

--- a/spec/automation_extensions/drivers/v4/options_spec.rb
+++ b/spec/automation_extensions/drivers/v4/options_spec.rb
@@ -1,45 +1,51 @@
 # frozen_string_literal: true
 RSpec.describe AutomationExtensions::Drivers::V4::Options do
+  let(:extension_class_options) { described_class.new(browser) }
+
   describe "#options" do
-    subject { described_class.new(browser).options }
+    subject { extension_class_options.options }
 
     context "for chrome" do
       let(:browser) { :chrome }
 
-      it "returns the correct v4 compliant options" do
-        expect(subject).to eq({})
-      end
+      it { is_expected.to have_attributes({ browser_name: "chrome" }) }
     end
 
     context "for firefox" do
       let(:browser) { :firefox }
 
-      it "returns the correct v4 compliant options" do
-        expect(subject).to eq({})
-      end
+      it { is_expected.to have_attributes({ browser_name: "firefox", log: { level: "info" } }) }
     end
 
     context "for internet explorer" do
       let(:browser) { :internet_explorer }
 
-      it "returns the correct v4 compliant options" do
-        expect(subject).to eq({})
-      end
+      it { is_expected.to have_attributes({ native_events: true, persistent_hover: true }) }
     end
 
     context "for safari" do
       let(:browser) { :safari }
 
-      it "returns the correct v4 compliant options" do
-        expect(subject).to eq({})
-      end
+      it { is_expected.to have_attributes({ browser_name: "safari", automatic_inspection: true }) }
     end
 
     context "for ios" do
       let(:browser) { :ios }
 
-      it "returns the correct v4 compliant options" do
-        expect(subject).to eq({})
+      it { is_expected.to be_empty }
+    end
+
+    context "for android" do
+      let(:browser) { :android }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "for an unsupported browser" do
+      let(:browser) { :foo }
+
+      it "Doesn't work if the browser is not one of the supported browsers" do
+        expect { subject }.to raise_error(NoMethodError)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 require "automation_extensions"
+require "selenium-webdriver"
+require "capybara"
 
 RSpec.configure(&:disable_monkey_patching!)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,5 +2,3 @@
 require "automation_extensions"
 require "selenium-webdriver"
 require "capybara"
-
-RSpec.configure(&:disable_monkey_patching!)


### PR DESCRIPTION
# Feature: Local Driver

This adds the first part of duplicated code to a common storage (here). This is for the first of 3 types of driver we configure - a "Local" Driver.
All of this is tested so the payload proc generation can be validated. **With the exception of safari**. However with the release (And consumption), of safari v14, this will likely vanish. So this is something I am reticent to code for atm, given it will vanish in time.

I've also structured the repo in such a way that later on, we can have different versioned selenium drivers (If truly needed), but for now I alias the local driver to be a v4 local driver

## Next Steps

- Cut this gem after merging this and test the usage of a v0.2 gem in the repos themselves.
- Add in Logger (ticket created for this)
- Add in remote drivers (Next driver steps)
- Begin to structure the patches side of the repo and have these executed down the line. (NB: These won't be tested, as they'll be monkeypatches waiting on fixes to come in).