### PR TITLE
Feature/np 1389 add logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **New**
 * Added CI pipeline to repo
+* Added Logging functionality to gem. Currently set to de-activated (Unknown level by default)
 
 **Removals**
 *

--- a/lib/ca_testing.rb
+++ b/lib/ca_testing.rb
@@ -14,6 +14,13 @@ module CaTesting
       @logger ||= CaTesting::Logger.new.create
     end
 
+    def logger=(logger)
+      raise ArgumentError, "You must supply an existing Logger" unless logger.is_a?(::Logger)
+
+      self.remove_instance_variable(:@logger) if instance_variable_defined?(:@logger)
+      @logger = logger
+    end
+
     def log_path=(logdev)
       logger.reopen(logdev)
     end

--- a/lib/ca_testing.rb
+++ b/lib/ca_testing.rb
@@ -17,7 +17,7 @@ module CaTesting
     def logger=(logger)
       raise ArgumentError, "You must supply an existing Logger" unless logger.is_a?(::Logger)
 
-      self.remove_instance_variable(:@logger) if instance_variable_defined?(:@logger)
+      remove_instance_variable(:@logger) if instance_variable_defined?(:@logger)
       @logger = logger
     end
 

--- a/lib/ca_testing.rb
+++ b/lib/ca_testing.rb
@@ -3,7 +3,7 @@ require "ca_testing/drivers"
 require "ca_testing/version"
 
 module CaTesting
-  autoload :Logger, 'ca_testing/logger'
+  autoload :Logger, "ca_testing/logger"
 
   class << self
     def configure

--- a/lib/ca_testing.rb
+++ b/lib/ca_testing.rb
@@ -1,3 +1,29 @@
 # frozen_string_literal: true
 require "ca_testing/drivers"
 require "ca_testing/version"
+
+module CaTesting
+  autoload :Logger, 'ca_testing/logger'
+
+  class << self
+    def configure
+      yield self
+    end
+
+    def logger
+      @logger ||= CaTesting::Logger.new.create
+    end
+
+    def log_path=(logdev)
+      logger.reopen(logdev)
+    end
+
+    def log_level=(value)
+      logger.level = value
+    end
+
+    def log_level
+      %i[DEBUG INFO WARN ERROR FATAL UNKNOWN][logger.level]
+    end
+  end
+end

--- a/lib/ca_testing.rb
+++ b/lib/ca_testing.rb
@@ -11,13 +11,12 @@ module CaTesting
     end
 
     def logger
-      @logger ||= CaTesting::Logger.new.create
+      @logger ||= Logger.create
     end
 
     def logger=(logger)
       raise ArgumentError, "You must supply an existing Logger" unless logger.is_a?(::Logger)
 
-      remove_instance_variable(:@logger) if instance_variable_defined?(:@logger)
       @logger = logger
     end
 

--- a/lib/ca_testing/drivers/v4/local.rb
+++ b/lib/ca_testing/drivers/v4/local.rb
@@ -47,9 +47,7 @@ module CaTesting
           ::Selenium::WebDriver::Remote::Capabilities.new.tap do |capabilities|
             if safari?
               capabilities["browserName"] = "Safari Technology Preview"
-              # TOFIX: Implement logger
-              # AutomationLogger.debug("Altering Browser Name request to alleviate Capybara failure with STP.")
-              warn "Altering Browser Name request to alleviate Capybara failure with STP."
+              CaTesting.logger.warn("Altering Browser Name request to alleviate Capybara failure with STP.")
             end
           end
         end

--- a/lib/ca_testing/drivers/v4/options.rb
+++ b/lib/ca_testing/drivers/v4/options.rb
@@ -33,11 +33,7 @@ module CaTesting
             # A Support ticket has been raised with Browserstack to see if they can fix
             # anything at their end, as this is a bug with their matching protocols
             # LH - Aug 2020
-
-            # TOFIX: Implement logger
-            # AutomationLogger.warn("Removing `browser_name` key from options payload.")
-            puts("Removing `browser_name` key from options payload.")
-
+            CaTesting.logger.info("Removing `browser_name` key from options payload.")
             opts.options.delete(:browser_name)
           end
         end

--- a/lib/ca_testing/logger.rb
+++ b/lib/ca_testing/logger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'logger'
+require "logger"
 
 module CaTesting
   #
@@ -9,7 +9,7 @@ module CaTesting
   class Logger
     def create(output = $stdout)
       logger = ::Logger.new(output)
-      logger.progname = 'Citizens Advice'
+      logger.progname = "Citizens Advice"
       logger.level = :UNKNOWN
       logger.formatter = proc do |severity, time, progname, msg|
         "#{time.strftime('%F %T')} - #{severity} - #{progname} - #{msg}\n"

--- a/lib/ca_testing/logger.rb
+++ b/lib/ca_testing/logger.rb
@@ -9,7 +9,7 @@ module CaTesting
   class Logger
     def create(output = $stdout)
       logger = ::Logger.new(output)
-      logger.progname = "Citizens Advice"
+      logger.progname = "CA Testing Gem"
       logger.level = :UNKNOWN
       logger.formatter = proc do |severity, time, progname, msg|
         "#{time.strftime('%F %T')} - #{severity} - #{progname} - #{msg}\n"

--- a/lib/ca_testing/logger.rb
+++ b/lib/ca_testing/logger.rb
@@ -7,7 +7,7 @@ module CaTesting
   # @api private
   #
   class Logger
-    def create(output = $stdout)
+    def self.create(output = $stdout)
       logger = ::Logger.new(output)
       logger.progname = "CA Testing Gem"
       logger.level = :UNKNOWN

--- a/lib/ca_testing/logger.rb
+++ b/lib/ca_testing/logger.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'logger'
+
+module CaTesting
+  #
+  # @api private
+  #
+  class Logger
+    def create(output = $stdout)
+      logger = ::Logger.new(output)
+      logger.progname = 'Citizens Advice'
+      logger.level = :UNKNOWN
+      logger.formatter = proc do |severity, time, progname, msg|
+        "#{time.strftime('%F %T')} - #{severity} - #{progname} - #{msg}\n"
+      end
+
+      logger
+    end
+  end
+end

--- a/spec/ca_testing/logger_spec.rb
+++ b/spec/ca_testing/logger_spec.rb
@@ -2,7 +2,7 @@
 
 describe CaTesting::Logger do
   describe "#create" do
-    subject(:logger) { described_class.new.create }
+    subject(:logger) { described_class.create }
 
     it { is_expected.to be_a Logger }
 

--- a/spec/ca_testing/logger_spec.rb
+++ b/spec/ca_testing/logger_spec.rb
@@ -7,7 +7,7 @@ describe CaTesting::Logger do
     it { is_expected.to be_a Logger }
 
     it "has a default name" do
-      expect(logger.progname).to eq("Citizens Advice")
+      expect(logger.progname).to eq("CA Testing Gem")
     end
 
     it "has a default logging level" do

--- a/spec/ca_testing/logger_spec.rb
+++ b/spec/ca_testing/logger_spec.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 describe CaTesting::Logger do
-  describe '#create' do
+  describe "#create" do
     subject(:logger) { described_class.new.create }
 
     it { is_expected.to be_a Logger }
 
-    it 'has a default name' do
-      expect(logger.progname).to eq('Citizens Advice')
+    it "has a default name" do
+      expect(logger.progname).to eq("Citizens Advice")
     end
 
-    it 'has a default logging level' do
+    it "has a default logging level" do
       expect(logger.level).to eq(5)
     end
   end

--- a/spec/ca_testing/logger_spec.rb
+++ b/spec/ca_testing/logger_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe CaTesting::Logger do
+  describe '#create' do
+    subject(:logger) { described_class.new.create }
+
+    it { is_expected.to be_a Logger }
+
+    it 'has a default name' do
+      expect(logger.progname).to eq('Citizens Advice')
+    end
+
+    it 'has a default logging level' do
+      expect(logger.level).to eq(5)
+    end
+  end
+end

--- a/spec/ca_testing_spec.rb
+++ b/spec/ca_testing_spec.rb
@@ -4,14 +4,14 @@ describe CaTesting do
   # Stop the $stdout process leaking cross-tests
   before { wipe_logger! }
 
-  describe '.configure' do
-    it 'can configure items in a configure block' do
+  describe ".configure" do
+    it "can configure items in a configure block" do
       expect(described_class).to receive(:configure).once
 
       described_class.configure { |_| :foo }
     end
 
-    it 'yields the configured options' do
+    it "yields the configured options" do
       expect(described_class).to receive(:log_level=).with(:WARN)
 
       described_class.configure do |config|
@@ -20,80 +20,80 @@ describe CaTesting do
     end
   end
 
-  describe '.logger' do
-    context 'with default severity' do
-      it 'does not log messages below UNKNOWN' do
+  describe ".logger" do
+    context "with default severity" do
+      it "does not log messages below UNKNOWN" do
         log_messages = capture_stdout do
-          described_class.logger.debug('DEBUG')
-          described_class.logger.fatal('FATAL')
+          described_class.logger.debug("DEBUG")
+          described_class.logger.fatal("FATAL")
         end
 
         expect(log_messages).to be_empty
       end
 
-      it 'logs UNKNOWN level messages' do
+      it "logs UNKNOWN level messages" do
         log_messages = capture_stdout do
-          described_class.logger.unknown('UNKNOWN')
+          described_class.logger.unknown("UNKNOWN")
         end
 
         expect(lines(log_messages)).to eq(1)
       end
     end
 
-    context 'with an altered severity' do
+    context "with an altered severity" do
       let(:log_messages) do
         capture_stdout do
           described_class.log_level = :DEBUG
 
-          described_class.logger.debug('DEBUG')
-          described_class.logger.info('INFO')
+          described_class.logger.debug("DEBUG")
+          described_class.logger.info("INFO")
         end
       end
 
-      it 'logs messages at all levels equal or above the new severity' do
+      it "logs messages at all levels equal or above the new severity" do
         expect(lines(log_messages)).to eq(2)
       end
     end
   end
 
-  describe '.log_path=' do
-    context 'when set to a file' do
-      let(:filename) { 'sample.log' }
+  describe ".log_path=" do
+    context "when set to a file" do
+      let(:filename) { "sample.log" }
       let(:file_content) { File.read(filename) }
 
       before { described_class.log_path = filename }
 
       after { File.delete(filename) if File.exist?(filename) }
 
-      it 'sends the log messages to the file-path provided' do
-        described_class.logger.unknown('This is sent to the file')
+      it "sends the log messages to the file-path provided" do
+        described_class.logger.unknown("This is sent to the file")
 
         expect(file_content).to end_with("This is sent to the file\n")
       end
     end
 
-    context 'when set to $stderr' do
-      it 'sends the log messages to $stderr' do
+    context "when set to $stderr" do
+      it "sends the log messages to $stderr" do
         expect do
           described_class.log_path = $stderr
-          described_class.logger.unknown('This is sent to $stderr')
+          described_class.logger.unknown("This is sent to $stderr")
         end.to output(/This is sent to \$stderr/).to_stderr
       end
     end
   end
 
-  describe '.log_level=' do
-    it 'can alter the log level' do
+  describe ".log_level=" do
+    it "can alter the log level" do
       expect(described_class).to respond_to(:log_level=)
     end
   end
 
-  describe '.log_level' do
+  describe ".log_level" do
     subject { described_class.log_level }
 
     it { is_expected.to eq(:UNKNOWN) }
 
-    context 'when changed to `INFO`' do
+    context "when changed to `INFO`" do
       before { described_class.log_level = :INFO }
 
       it { is_expected.to eq(:INFO) }

--- a/spec/ca_testing_spec.rb
+++ b/spec/ca_testing_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+describe CaTesting do
+  # Stop the $stdout process leaking cross-tests
+  before { wipe_logger! }
+
+  describe '.configure' do
+    it 'can configure items in a configure block' do
+      expect(described_class).to receive(:configure).once
+
+      described_class.configure { |_| :foo }
+    end
+
+    it 'yields the configured options' do
+      expect(described_class).to receive(:log_level=).with(:WARN)
+
+      described_class.configure do |config|
+        config.log_level = :WARN
+      end
+    end
+  end
+
+  describe '.logger' do
+    context 'with default severity' do
+      it 'does not log messages below UNKNOWN' do
+        log_messages = capture_stdout do
+          described_class.logger.debug('DEBUG')
+          described_class.logger.fatal('FATAL')
+        end
+
+        expect(log_messages).to be_empty
+      end
+
+      it 'logs UNKNOWN level messages' do
+        log_messages = capture_stdout do
+          described_class.logger.unknown('UNKNOWN')
+        end
+
+        expect(lines(log_messages)).to eq(1)
+      end
+    end
+
+    context 'with an altered severity' do
+      let(:log_messages) do
+        capture_stdout do
+          described_class.log_level = :DEBUG
+
+          described_class.logger.debug('DEBUG')
+          described_class.logger.info('INFO')
+        end
+      end
+
+      it 'logs messages at all levels equal or above the new severity' do
+        expect(lines(log_messages)).to eq(2)
+      end
+    end
+  end
+
+  describe '.log_path=' do
+    context 'when set to a file' do
+      let(:filename) { 'sample.log' }
+      let(:file_content) { File.read(filename) }
+
+      before { described_class.log_path = filename }
+
+      after { File.delete(filename) if File.exist?(filename) }
+
+      it 'sends the log messages to the file-path provided' do
+        described_class.logger.unknown('This is sent to the file')
+
+        expect(file_content).to end_with("This is sent to the file\n")
+      end
+    end
+
+    context 'when set to $stderr' do
+      it 'sends the log messages to $stderr' do
+        expect do
+          described_class.log_path = $stderr
+          described_class.logger.unknown('This is sent to $stderr')
+        end.to output(/This is sent to \$stderr/).to_stderr
+      end
+    end
+  end
+
+  describe '.log_level=' do
+    it 'can alter the log level' do
+      expect(described_class).to respond_to(:log_level=)
+    end
+  end
+
+  describe '.log_level' do
+    subject { described_class.log_level }
+
+    it { is_expected.to eq(:UNKNOWN) }
+
+    context 'when changed to `INFO`' do
+      before { described_class.log_level = :INFO }
+
+      it { is_expected.to eq(:INFO) }
+    end
+  end
+end

--- a/spec/ca_testing_spec.rb
+++ b/spec/ca_testing_spec.rb
@@ -56,6 +56,30 @@ describe CaTesting do
     end
   end
 
+  describe ".logger=" do
+    context "with a valid Logger input" do
+      let(:existing_logger) { described_class.logger }
+      let(:new_logger) { ::Logger.new($stdout) }
+
+      it "does not raise an error" do
+        expect { described_class.logger = new_logger }.not_to raise_error
+      end
+
+      it "sets the Logger to the new type" do
+        expect { described_class.logger = new_logger }.to change { described_class.logger }.from(existing_logger).to(new_logger)
+      end
+    end
+
+    context "with an invalid Logger input" do
+      let(:existing_logger) { described_class.logger }
+      let(:new_logger) { :not_a_logger }
+
+      it "raises an ArgumentError" do
+        expect { described_class.logger = new_logger }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
   describe ".log_path=" do
     context "when set to a file" do
       let(:filename) { "sample.log" }

--- a/spec/ca_testing_spec.rb
+++ b/spec/ca_testing_spec.rb
@@ -57,21 +57,20 @@ describe CaTesting do
   end
 
   describe ".logger=" do
+    let(:existing_logger) { described_class.logger }
+
     context "with a valid Logger input" do
-      let(:existing_logger) { described_class.logger }
       let(:new_logger) { ::Logger.new($stdout) }
 
-      it "does not raise an error" do
-        expect { described_class.logger = new_logger }.not_to raise_error
-      end
-
       it "sets the Logger to the new type" do
-        expect { described_class.logger = new_logger }.to change { described_class.logger }.from(existing_logger).to(new_logger)
+        expect { described_class.logger = new_logger }
+          .to change { described_class.logger }
+          .from(existing_logger)
+          .to(new_logger)
       end
     end
 
     context "with an invalid Logger input" do
-      let(:existing_logger) { described_class.logger }
       let(:new_logger) { :not_a_logger }
 
       it "raises an ArgumentError" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,22 @@
 require "ca_testing"
 require "selenium-webdriver"
 require "capybara"
+
+def capture_stdout
+  original_stdout = $stdout
+  $stdout = StringIO.new
+  yield
+  $stdout.string
+ensure
+  $stdout = original_stdout
+end
+
+def wipe_logger!
+  return unless CaTesting.instance_variable_get(:@logger)
+
+  CaTesting.remove_instance_variable(:@logger)
+end
+
+def lines(string)
+  string.split("\n").length
+end


### PR DESCRIPTION
Add's a standard Ruby Logger to the gem.
The gem can either just function without any configuration (This will use a newly created one piping to stdout), or you can write a logger instance to it which will then pipe all of it's messages to that logger.

NB: In both instances you can alter the log level / output location in the normal way