### PR TITLE
Change capabilities order for Safari (Mitigate missing browserName key)

### DIFF
--- a/lib/ca_testing/drivers/v4/local.rb
+++ b/lib/ca_testing/drivers/v4/local.rb
@@ -19,9 +19,14 @@ module CaTesting
               app,
               browser: browser,
               service: service,
-              capabilities: [desired_capabilities, options]
+              capabilities: capabilities
             )
           end
+        end
+
+        #The order of this is important because Safari Tech Preview set the name twice
+        def capabilities
+          [options, desired_capabilities]
         end
 
         private

--- a/lib/ca_testing/drivers/v4/local.rb
+++ b/lib/ca_testing/drivers/v4/local.rb
@@ -29,7 +29,11 @@ module CaTesting
         # as such we need to ensure the browserName we manually set in `desired_capabilities`
         # is retained as this is the one required by safari
         def capabilities
-          [options, desired_capabilities]
+          if safari?
+            [options, desired_capabilities]
+          else
+            [desired_capabilities, options]
+          end
         end
 
         private

--- a/lib/ca_testing/drivers/v4/local.rb
+++ b/lib/ca_testing/drivers/v4/local.rb
@@ -24,7 +24,10 @@ module CaTesting
           end
         end
 
-        #The order of this is important because Safari Tech Preview set the name twice
+        # The order of these capabilities is important because in the internal configuration
+        # for the driver; these 2 objects are merged (And both will contain a browserName)
+        # as such we need to ensure the browserName we manually set in `desired_capabilities`
+        # is retained as this is the one required by safari
         def capabilities
           [options, desired_capabilities]
         end


### PR DESCRIPTION
Change the order of capabilities because Safari Tech Preview set the name twice.