### PR TITLE
Bugfix/add safari tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 *
 
 **Bugfixes**
-*
+* Add Local Safari driver tests
+  * Previously these complained of an issue in missing browser / driver. This is now stubbed
 
 ## <sub>v0.2.1</sub>
 #### _Jan. 11, 2020_

--- a/spec/ca_testing/drivers/v4/local_spec.rb
+++ b/spec/ca_testing/drivers/v4/local_spec.rb
@@ -8,13 +8,14 @@ RSpec.describe CaTesting::Drivers::V4::Local do
   subject(:options) { session.driver.options }
 
   let(:session) { Capybara::Session.new(:selenium) }
+  let(:standard_top_level_properties) { %i[browser clear_local_storage clear_session_storage service capabilities] }
 
   describe "#register" do
     context "for chrome" do
       let(:browser) { :chrome }
 
       it "has correct top level properties" do
-        expect(options.keys).to eq(%i[browser clear_local_storage clear_session_storage service capabilities])
+        expect(options.keys).to eq(standard_top_level_properties)
       end
 
       it "has correct desired capabilities" do
@@ -36,7 +37,7 @@ RSpec.describe CaTesting::Drivers::V4::Local do
       let(:browser) { :firefox }
 
       it "has correct top level properties" do
-        expect(options.keys).to eq(%i[browser clear_local_storage clear_session_storage service capabilities])
+        expect(options.keys).to eq(standard_top_level_properties)
       end
 
       it "has correct desired capabilities" do
@@ -58,7 +59,7 @@ RSpec.describe CaTesting::Drivers::V4::Local do
       let(:browser) { :internet_explorer }
 
       it "has correct top level properties" do
-        expect(options.keys).to eq(%i[browser clear_local_storage clear_session_storage service capabilities])
+        expect(options.keys).to eq(standard_top_level_properties)
       end
 
       it "has correct desired capabilities" do
@@ -70,6 +71,31 @@ RSpec.describe CaTesting::Drivers::V4::Local do
           .to eq(
             {
               "se:ieOptions" => { "enablePersistentHover" => true, "nativeEvents" => true }
+            }
+          )
+      end
+    end
+
+    context "for safari" do
+      let(:browser) { :safari }
+
+      # Prevent Docker container complaining it doesn't know where safari is!
+      before { allow(Selenium::WebDriver::Platform).to receive(:assert_executable) }
+
+      it "has correct top level properties" do
+        expect(options.keys).to eq(standard_top_level_properties)
+      end
+
+      it "has correct desired capabilities" do
+        expect(options[:capabilities].last.as_json).to eq({ "browserName" => "Safari Technology Preview" })
+      end
+
+      it "has correct browser options" do
+        expect(options[:capabilities].first.as_json)
+          .to eq(
+            {
+              "browserName" => "safari",
+              "safari:automaticInspection" => true
             }
           )
       end


### PR DESCRIPTION
This will allow us to validate our local safari drivers. By simply stubbing out the root validator in Selenium.

This takes us back to full test coverage again