### PR TITLE
Feature/Add remote driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 *
 
 **New**
-*
+* Added remote (grid), driver creation
 
 **Removals**
 *

--- a/lib/ca_testing/drivers.rb
+++ b/lib/ca_testing/drivers.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 require "ca_testing/drivers/local"
+require "ca_testing/drivers/remote"
 require "ca_testing/drivers/v4"

--- a/lib/ca_testing/drivers/remote.rb
+++ b/lib/ca_testing/drivers/remote.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
-require "ca_testing/drivers/v4/local"
 require "ca_testing/drivers/v4/remote"
+
+module CaTesting
+  module Drivers
+    Remote = V4::Remote
+  end
+end

--- a/lib/ca_testing/drivers/v4/remote.rb
+++ b/lib/ca_testing/drivers/v4/remote.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "ca_testing/drivers/v4/options"
+
+module CaTesting
+  module Drivers
+    module V4
+      class Local
+        def register
+          Capybara.register_driver :selenium do |app|
+            Capybara::Selenium::Driver.new(
+              app,
+              browser: :remote,
+              capabilities: [browser_capabilities, options],
+              url: hub_url
+            )
+          end
+        end
+
+        private
+
+        def browser_capabilities
+          case browser
+          when :chrome;            then Selenium::WebDriver::Remote::Capabilities.chrome
+          when :firefox;           then Selenium::WebDriver::Remote::Capabilities.firefox
+          when :internet_explorer; then Selenium::WebDriver::Remote::Capabilities.internet_explorer
+          else                     raise StandardError, "Not implemented"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ca_testing/drivers/v4/remote.rb
+++ b/lib/ca_testing/drivers/v4/remote.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
 require "ca_testing/drivers/v4/options"
+require "selenium/webdriver/remote/capabilities"
 
 module CaTesting
   module Drivers
     module V4
       class Local
+        attr_reader :browser
+        private :browser
+
+        def initialize(browser)
+          @browser = browser
+        end
+
         def register
           Capybara.register_driver :selenium do |app|
             Capybara::Selenium::Driver.new(
@@ -24,8 +32,16 @@ module CaTesting
           when :chrome;            then Selenium::WebDriver::Remote::Capabilities.chrome
           when :firefox;           then Selenium::WebDriver::Remote::Capabilities.firefox
           when :internet_explorer; then Selenium::WebDriver::Remote::Capabilities.internet_explorer
-          else                     raise StandardError, "Not implemented"
+          else                     raise ArgumentError, "You must use a supported browser"
           end
+        end
+
+        def options
+          Options.new(browser).options
+        end
+
+        def hub_url
+          ENV["HUB_URL"]
         end
       end
     end

--- a/lib/ca_testing/drivers/v4/remote.rb
+++ b/lib/ca_testing/drivers/v4/remote.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 require "ca_testing/drivers/v4/options"
-require "selenium/webdriver/remote/capabilities"
+require "selenium/webdriver/remote"
 
 module CaTesting
   module Drivers
     module V4
-      class Local
+      class Remote
         attr_reader :browser
         private :browser
 

--- a/lib/ca_testing/drivers/v4/remote.rb
+++ b/lib/ca_testing/drivers/v4/remote.rb
@@ -31,7 +31,6 @@ module CaTesting
           case browser
           when :chrome;            then Selenium::WebDriver::Remote::Capabilities.chrome
           when :firefox;           then Selenium::WebDriver::Remote::Capabilities.firefox
-          when :internet_explorer; then Selenium::WebDriver::Remote::Capabilities.internet_explorer
           else                     raise ArgumentError, "You must use a supported browser"
           end
         end

--- a/spec/ca_testing/drivers/local_spec.rb
+++ b/spec/ca_testing/drivers/local_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 RSpec.describe CaTesting::Drivers::Local do
-  it "Aliases the shorter context to the V4 namespace" do
+  it "aliases the shorter context to the V4 namespace" do
     expect(described_class.new(double)).to be_a(CaTesting::Drivers::V4::Local)
   end
 end

--- a/spec/ca_testing/drivers/remote_spec.rb
+++ b/spec/ca_testing/drivers/remote_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+RSpec.describe CaTesting::Drivers::Remote do
+  it "Aliases the shorter context to the V4 namespace" do
+    expect(described_class.new(double)).to be_a(CaTesting::Drivers::V4::Remote)
+  end
+end

--- a/spec/ca_testing/drivers/remote_spec.rb
+++ b/spec/ca_testing/drivers/remote_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 RSpec.describe CaTesting::Drivers::Remote do
-  it "Aliases the shorter context to the V4 namespace" do
+  it "aliases the shorter context to the V4 namespace" do
     expect(described_class.new(double)).to be_a(CaTesting::Drivers::V4::Remote)
   end
 end

--- a/spec/ca_testing/drivers/v4/local_spec.rb
+++ b/spec/ca_testing/drivers/v4/local_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe CaTesting::Drivers::V4::Local do
     context "for an unsupported browser" do
       let(:browser) { :foo }
 
-      it "Doesn't work if the browser is not one of the supported browsers" do
+      it "doesn't work if the browser is not one of the supported browsers" do
         expect { options }.to raise_error(NoMethodError)
       end
     end

--- a/spec/ca_testing/drivers/v4/options_spec.rb
+++ b/spec/ca_testing/drivers/v4/options_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe CaTesting::Drivers::V4::Options do
     context "for an unsupported browser" do
       let(:browser) { :foo }
 
-      it "Doesn't work if the browser is not one of the supported browsers" do
+      it "doesn't work if the browser is not one of the supported browsers" do
         expect { subject }.to raise_error(NoMethodError)
       end
     end

--- a/spec/ca_testing/drivers/v4/remote_spec.rb
+++ b/spec/ca_testing/drivers/v4/remote_spec.rb
@@ -54,33 +54,6 @@ RSpec.describe CaTesting::Drivers::V4::Remote do
       end
     end
 
-    context "for internet explorer" do
-      let(:browser) { :internet_explorer }
-
-      it "has correct top level properties" do
-        expect(options.keys).to eq(%i[browser clear_local_storage clear_session_storage capabilities url])
-      end
-
-      it "has correct desired capabilities" do
-        expect(options[:capabilities].first.as_json)
-          .to eq(
-            {
-              "browserName" => "internet explorer",
-              "platformName" => :windows
-            }
-          )
-      end
-
-      it "has correct (Modified), browser options" do
-        expect(options[:capabilities].last.as_json)
-          .to eq(
-            {
-              "se:ieOptions" => { "enablePersistentHover" => true, "nativeEvents" => true }
-            }
-          )
-      end
-    end
-
     context "for an unsupported browser" do
       let(:browser) { :foo }
 

--- a/spec/ca_testing/drivers/v4/remote_spec.rb
+++ b/spec/ca_testing/drivers/v4/remote_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe CaTesting::Drivers::V4::Remote do
     context "for an unsupported browser" do
       let(:browser) { :foo }
 
-      it "Doesn't work if the browser is not one of the supported browsers" do
+      it "doesn't work if the browser is not one of the supported browsers" do
         expect { options }.to raise_error(ArgumentError)
       end
     end

--- a/spec/ca_testing/drivers/v4/remote_spec.rb
+++ b/spec/ca_testing/drivers/v4/remote_spec.rb
@@ -62,7 +62,13 @@ RSpec.describe CaTesting::Drivers::V4::Remote do
       end
 
       it "has correct desired capabilities" do
-        expect(options[:capabilities].first.as_json).to eq({ "browserName" => "internet explorer", "platormName" => :windows })
+        expect(options[:capabilities].first.as_json)
+          .to eq(
+            {
+              "browserName" => "internet explorer",
+              "platformName" => :windows
+            }
+          )
       end
 
       it "has correct (Modified), browser options" do

--- a/spec/ca_testing/drivers/v4/remote_spec.rb
+++ b/spec/ca_testing/drivers/v4/remote_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+RSpec.describe CaTesting::Drivers::V4::Remote do
+  before do
+    Capybara.default_driver = :selenium
+    described_class.new(browser).register
+  end
+
+  subject(:options) { session.driver.options }
+
+  let(:session) { Capybara::Session.new(:selenium) }
+
+  describe "#register" do
+    context "for chrome" do
+      let(:browser) { :chrome }
+
+      it "has correct top level properties" do
+        expect(options.keys).to eq(%i[browser clear_local_storage clear_session_storage capabilities url])
+      end
+
+      it "has correct desired capabilities" do
+        expect(options[:capabilities].first.as_json).to eq({ "browserName" => "chrome" })
+      end
+
+      it "has correct browser options" do
+        expect(options[:capabilities].last.as_json)
+          .to eq(
+            {
+              "browserName" => "chrome",
+              "goog:chromeOptions" => {}
+            }
+          )
+      end
+    end
+
+    context "for firefox" do
+      let(:browser) { :firefox }
+
+      it "has correct top level properties" do
+        expect(options.keys).to eq(%i[browser clear_local_storage clear_session_storage capabilities url])
+      end
+
+      it "has correct desired capabilities" do
+        expect(options[:capabilities].first.as_json).to eq({ "browserName" => "firefox" })
+      end
+
+      it "has correct browser options" do
+        expect(options[:capabilities].last.as_json)
+          .to eq(
+            {
+              "browserName" => "firefox",
+              "moz:firefoxOptions" => { "log" => { "level" => "info" } }
+            }
+          )
+      end
+    end
+
+    context "for internet explorer" do
+      let(:browser) { :internet_explorer }
+
+      it "has correct top level properties" do
+        expect(options.keys).to eq(%i[browser clear_local_storage clear_session_storage capabilities url])
+      end
+
+      it "has correct desired capabilities" do
+        expect(options[:capabilities].first.as_json).to eq({ "browserName" => "internet explorer", "platormName" => :windows })
+      end
+
+      it "has correct (Modified), browser options" do
+        expect(options[:capabilities].last.as_json)
+          .to eq(
+            {
+              "se:ieOptions" => { "enablePersistentHover" => true, "nativeEvents" => true }
+            }
+          )
+      end
+    end
+
+    context "for an unsupported browser" do
+      let(:browser) { :foo }
+
+      it "Doesn't work if the browser is not one of the supported browsers" do
+        expect { options }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end

--- a/spec/ca_testing/logger_spec.rb
+++ b/spec/ca_testing/logger_spec.rb
@@ -10,7 +10,7 @@ describe CaTesting::Logger do
       expect(logger.progname).to eq("CA Testing Gem")
     end
 
-    it "has a default logging level" do
+    it "is turned off by default" do
       expect(logger.level).to eq(5)
     end
   end


### PR DESCRIPTION
Migrates the 2nd type of driver over (A Remote Driver, used for Selenium Hubs we host).

After this the only type of driver to migrate is the Browserstack one (Which is a bit trickier).