### PR TITLE
Feature/patch framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 *
 
 **New**
-*
+* Added sample code / specs for patches
+  * This will now enable all future patches to conform to a sensible structure
 
 **Updates**
 * The docker files are now slightly lighter

--- a/lib/ca_testing.rb
+++ b/lib/ca_testing.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 require "ca_testing/drivers"
+require "ca_testing/logger"
+require "ca_testing/patches"
 require "ca_testing/version"
 
 module CaTesting
-  autoload :Logger, "ca_testing/logger"
-
   class << self
     def configure
       yield self

--- a/lib/ca_testing/patches.rb
+++ b/lib/ca_testing/patches.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+require "ca_testing/patches/sample"

--- a/lib/ca_testing/patches/sample.rb
+++ b/lib/ca_testing/patches/sample.rb
@@ -22,7 +22,7 @@ module CaTesting
       end
 
       def perform
-        :this_will_edit_some_code
+        @changed_behaviour = :foo
       end
 
       def deprecate?

--- a/lib/ca_testing/patches/sample.rb
+++ b/lib/ca_testing/patches/sample.rb
@@ -23,7 +23,7 @@ module CaTesting
       end
 
       def perform
-        @changed_behaviour = :foo
+        :change_some_behaviour
       end
 
       def deprecate?

--- a/lib/ca_testing/patches/sample.rb
+++ b/lib/ca_testing/patches/sample.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module CaTesting
+  module Patches
+    class Sample
+      def patch!
+        CaTesting.logger.info("Adding patch: #{self.class}")
+        CaTesting.logger.debug(description)
+        perform
+        CaTesting.logger.info("Patch successfully added.")
+        Kernel.warn("This is now deprecated and should not be used") if deprecate?
+        raise "This is no longer supported" if prevent_usage?
+      end
+
+      private
+
+      def description
+        <<~DESCRIPTION
+          This is a sample patch. The file/class structure is here.
+          We will remove this sample file once we have a couple of sample patches merged
+        DESCRIPTION
+      end
+
+      def perform
+        :this_will_edit_some_code
+      end
+
+      def deprecate?
+        Time.new > deprecation_notice_date
+      end
+
+      def deprecation_notice_date
+        Time.new(2021, 2, 2)
+      end
+
+      def prevent_usage?
+        Time.new > prevent_usage_date
+      end
+
+      def prevent_usage_date
+        Time.new(2021, 5, 2)
+      end
+    end
+  end
+end

--- a/lib/ca_testing/patches/sample.rb
+++ b/lib/ca_testing/patches/sample.rb
@@ -4,12 +4,13 @@ module CaTesting
   module Patches
     class Sample
       def patch!
+        raise "This is no longer supported" if prevent_usage?
+
+        Kernel.warn("This is now deprecated and should not be used") if deprecate?
         CaTesting.logger.info("Adding patch: #{self.class}")
         CaTesting.logger.debug(description)
         perform
         CaTesting.logger.info("Patch successfully added.")
-        Kernel.warn("This is now deprecated and should not be used") if deprecate?
-        raise "This is no longer supported" if prevent_usage?
       end
 
       private

--- a/spec/ca_testing/patches/sample_spec.rb
+++ b/spec/ca_testing/patches/sample_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe CaTesting::Patches::Sample do
   before do
     allow(subject).to receive(:deprecate?).and_return(deprecate?)
     allow(subject).to receive(:prevent_usage?).and_return(prevent_usage?)
+    allow(Kernel).to receive(:warn)
   end
 
   let(:deprecate?) { false }

--- a/spec/ca_testing/patches/sample_spec.rb
+++ b/spec/ca_testing/patches/sample_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe CaTesting::Patches::Sample do
     allow(subject).to receive(:prevent_usage?).and_return(prevent_usage?)
   end
 
+  let(:deprecate?) { false }
+  let(:prevent_usage?) { false }
+
   describe "#patch!" do
     context "when permissible" do
-      let(:deprecate?) { false }
-      let(:prevent_usage?) { false }
-
       it "performs the patch successfully" do
         expect { subject.patch! }.to change { subject.instance_variable_get(:@changed_behaviour) }
       end
@@ -17,7 +17,6 @@ RSpec.describe CaTesting::Patches::Sample do
 
     context "when deprecated" do
       let(:deprecate?) { true }
-      let(:prevent_usage?) { false }
 
       it "performs the patch successfully" do
         expect { subject.patch! }.to change { subject.instance_variable_get(:@changed_behaviour) }
@@ -31,7 +30,6 @@ RSpec.describe CaTesting::Patches::Sample do
     end
 
     context "when EOL" do
-      let(:deprecate?) { true }
       let(:prevent_usage?) { true }
 
       it "raises an Error" do

--- a/spec/ca_testing/patches/sample_spec.rb
+++ b/spec/ca_testing/patches/sample_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe CaTesting::Patches::Sample do
   describe "#patch!" do
     context "when permissible" do
       it "performs the patch successfully" do
-        expect { subject.patch! }.to change { subject.instance_variable_get(:@changed_behaviour) }
+        expect(subject).to receive(:perform)
+
+        subject.patch!
       end
     end
 
@@ -19,7 +21,9 @@ RSpec.describe CaTesting::Patches::Sample do
       let(:deprecate?) { true }
 
       it "performs the patch successfully" do
-        expect { subject.patch! }.to change { subject.instance_variable_get(:@changed_behaviour) }
+        expect(subject).to receive(:perform)
+
+        subject.patch!
       end
 
       it "notifies the user that it is deprecated" do
@@ -34,12 +38,6 @@ RSpec.describe CaTesting::Patches::Sample do
 
       it "raises an Error" do
         expect { subject.patch! }.to raise_error(RuntimeError).with_message("This is no longer supported")
-      end
-
-      it "does not attempt to patch any files" do
-        expect(subject).not_to receive(:perform)
-
-        subject.patch!
       end
     end
   end

--- a/spec/ca_testing/patches/sample_spec.rb
+++ b/spec/ca_testing/patches/sample_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+RSpec.describe CaTesting::Patches::Sample do
+  before do
+    allow(subject).to receive(:deprecate?).and_return(deprecate?)
+    allow(subject).to receive(:prevent_usage?).and_return(prevent_usage?)
+  end
+
+  describe "#patch!" do
+    context "when permissible" do
+      let(:deprecate?) { false }
+      let(:prevent_usage?) { false }
+
+      it "performs the patch successfully" do
+        expect { subject.patch! }.to change { subject.instance_variable_get(:@changed_behaviour) }
+      end
+    end
+
+    context "when deprecated" do
+      let(:deprecate?) { true }
+      let(:prevent_usage?) { false }
+
+      it "performs the patch successfully" do
+        expect { subject.patch! }.to change { subject.instance_variable_get(:@changed_behaviour) }
+      end
+
+      it "notifies the user that it is deprecated" do
+        expect(Kernel).to receive(:warn).with("This is now deprecated and should not be used")
+
+        subject.patch!
+      end
+    end
+
+    context "when EOL" do
+      let(:deprecate?) { true }
+      let(:prevent_usage?) { true }
+
+      it "raises an Error" do
+        expect { subject.patch! }.to raise_error(RuntimeError).with_message("This is no longer supported")
+      end
+
+      it "does not attempt to patch any files" do
+        expect(subject).not_to receive(:perform)
+
+        subject.patch!
+      end
+    end
+  end
+end


### PR DESCRIPTION
Framework for how to structure upcoming work that will be patch oriented.

Regular extensions won't be affected and will just live in `ca_testing/extensions` and can be tested much easier. These are just a bit more awkward.

Have also put in a sample piece of code/test - Although this should be removed in the next couple of months. Once we've got a few legit patches in place.