### PR TITLE
Feature/np 1578 logger patch

### DIFF
--- a/lib/ca_testing/patches.rb
+++ b/lib/ca_testing/patches.rb
@@ -1,2 +1,4 @@
 # frozen_string_literal: true
+require "ca_testing/patches/base"
+require "ca_testing/patches/logger"
 require "ca_testing/patches/sample"

--- a/lib/ca_testing/patches/base.rb
+++ b/lib/ca_testing/patches/base.rb
@@ -25,6 +25,10 @@ module CaTesting
       def prevent_usage?
         Time.new > prevent_usage_date
       end
+
+      def prevent_usage_date
+        Time.new(3000, 1, 1)
+      end
     end
   end
 end

--- a/lib/ca_testing/patches/base.rb
+++ b/lib/ca_testing/patches/base.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module CaTesting
+  module Patches
+    class Base
+      #
+      # api private (Not intended to be instantiated directly!)
+      #
+      def patch!
+        raise "This is no longer supported" if prevent_usage?
+
+        Kernel.warn("This is now deprecated and should not be used") if deprecate?
+        CaTesting.logger.info("Adding patch: #{self.class}")
+        CaTesting.logger.debug(description)
+        perform
+        CaTesting.logger.info("Patch successfully added.")
+      end
+
+      private
+
+      def deprecate?
+        Time.new > deprecation_notice_date
+      end
+
+      def prevent_usage?
+        Time.new > prevent_usage_date
+      end
+    end
+  end
+end

--- a/lib/ca_testing/patches/logger.rb
+++ b/lib/ca_testing/patches/logger.rb
@@ -16,6 +16,8 @@ module CaTesting
           can return unencoded binary (confusingly called ASCII-8BIT in Ruby).
           Consequently we set the logger to binmode so it doesn't try to encode the data - this would always
           cause errors for non-ASCII characters, whatever the parent encoding is. An example of this is ©.
+
+          See https://github.com/ruby/net-http/issues/14 for a root cause analysis of the Adapter
         DESCRIPTION
       end
 

--- a/lib/ca_testing/patches/logger.rb
+++ b/lib/ca_testing/patches/logger.rb
@@ -18,20 +18,9 @@ module CaTesting
       end
 
       def perform
-        # Store previously set values
-        previous_internal = Encoding.default_internal
-        previous_external = Encoding.default_external
-
-        # Set them to ASCII_8BIT which seems to like writing special characters
-        Encoding.default_internal = Encoding.default_external = Encoding::ASCII_8BIT
-
-        # Set the outputter property to write to this desired encoding
+        # Set the outputter encoding to write to ASCII 8BIT (Which likes writing weird characters)
         outputter = @logger.instance_variable_get(:@logdev).dev
-        outputter.set_encoding(Encoding.default_internal, Encoding.default_external)
-
-        # Restore previous values
-        Encoding.default_internal = previous_internal
-        Encoding.default_external = previous_external
+        outputter.set_encoding(Encoding::ASCII_8BIT, Encoding::ASCII_8BIT)
       end
 
       def deprecation_notice_date

--- a/lib/ca_testing/patches/logger.rb
+++ b/lib/ca_testing/patches/logger.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module CaTesting
+  module Patches
+    class Logger
+      def patch!
+        raise "This is no longer supported" if prevent_usage?
+
+        Kernel.warn("This is now deprecated and should not be used") if deprecate?
+        CaTesting.logger.info("Adding patch: #{self.class}")
+        CaTesting.logger.debug(description)
+        perform
+        CaTesting.logger.info("Patch successfully added.")
+      end
+
+      private
+
+      def description
+        <<~DESCRIPTION
+          This enables any Logger to convert it's encoding to one which supports special characters.
+          Examples of this are things like © which use the ASCII encoding protocol (Instead of UTF-8).
+        DESCRIPTION
+      end
+
+      def perform
+        :change_some_behaviour
+      end
+
+      def deprecate?
+        Time.new > deprecation_notice_date
+      end
+
+      def deprecation_notice_date
+        Time.new(2022, 1, 1)
+      end
+
+      def prevent_usage?
+        Time.new > prevent_usage_date
+      end
+
+      def prevent_usage_date
+        Time.new(3000, 1, 1)
+      end
+    end
+  end
+end

--- a/lib/ca_testing/patches/logger.rb
+++ b/lib/ca_testing/patches/logger.rb
@@ -26,10 +26,6 @@ module CaTesting
       def deprecation_notice_date
         Time.new(2022, 1, 1)
       end
-
-      def prevent_usage_date
-        Time.new(3000, 1, 1)
-      end
     end
   end
 end

--- a/lib/ca_testing/patches/logger.rb
+++ b/lib/ca_testing/patches/logger.rb
@@ -12,19 +12,19 @@ module CaTesting
 
       def description
         <<~DESCRIPTION
-          This enables any Logger to convert it's encoding to one which supports special characters.
-          Examples of this are things like © which use the ASCII encoding protocol (Instead of UTF-8).
+          When using the Selenium Logger that is set to pipe to a file, the Net::HTTP adapter (default),
+          can return unencoded binary (confusingly called ASCII-8BIT in Ruby).
+          Consequently we set the logger to binmode so it doesn't try to encode the data - this would always
+          cause errors for non-ASCII characters, whatever the parent encoding is. An example of this is ©.
         DESCRIPTION
       end
 
       def perform
-        # Set the outputter encoding to write to ASCII 8BIT (Which likes writing weird characters)
-        outputter = @logger.instance_variable_get(:@logdev).dev
-        outputter.set_encoding(Encoding::ASCII_8BIT, Encoding::ASCII_8BIT)
+        Selenium::WebDriver.logger.io.binmode
       end
 
-      def deprecation_notice_date
-        Time.new(2022, 1, 1)
+      def deprecate?
+        false
       end
     end
   end

--- a/lib/ca_testing/patches/logger.rb
+++ b/lib/ca_testing/patches/logger.rb
@@ -3,6 +3,11 @@
 module CaTesting
   module Patches
     class Logger < Base
+      def initialize(logger)
+        @logger = logger
+        super()
+      end
+
       private
 
       def description
@@ -13,7 +18,20 @@ module CaTesting
       end
 
       def perform
-        :change_some_behaviour
+        # Store previously set values
+        previous_internal = Encoding.default_internal
+        previous_external = Encoding.default_external
+
+        # Set them to ASCII_8BIT which seems to like writing special characters
+        Encoding.default_internal = Encoding.default_external = Encoding::ASCII_8BIT
+
+        # Set the outputter property to write to this desired encoding
+        outputter = @logger.instance_variable_get(:@logdev).dev
+        outputter.set_encoding(Encoding.default_internal, Encoding.default_external)
+
+        # Restore previous values
+        Encoding.default_internal = previous_internal
+        Encoding.default_external = previous_external
       end
 
       def deprecation_notice_date

--- a/lib/ca_testing/patches/logger.rb
+++ b/lib/ca_testing/patches/logger.rb
@@ -2,17 +2,7 @@
 
 module CaTesting
   module Patches
-    class Logger
-      def patch!
-        raise "This is no longer supported" if prevent_usage?
-
-        Kernel.warn("This is now deprecated and should not be used") if deprecate?
-        CaTesting.logger.info("Adding patch: #{self.class}")
-        CaTesting.logger.debug(description)
-        perform
-        CaTesting.logger.info("Patch successfully added.")
-      end
-
+    class Logger < Base
       private
 
       def description
@@ -26,16 +16,8 @@ module CaTesting
         :change_some_behaviour
       end
 
-      def deprecate?
-        Time.new > deprecation_notice_date
-      end
-
       def deprecation_notice_date
         Time.new(2022, 1, 1)
-      end
-
-      def prevent_usage?
-        Time.new > prevent_usage_date
       end
 
       def prevent_usage_date

--- a/lib/ca_testing/patches/sample.rb
+++ b/lib/ca_testing/patches/sample.rb
@@ -2,17 +2,7 @@
 
 module CaTesting
   module Patches
-    class Sample
-      def patch!
-        raise "This is no longer supported" if prevent_usage?
-
-        Kernel.warn("This is now deprecated and should not be used") if deprecate?
-        CaTesting.logger.info("Adding patch: #{self.class}")
-        CaTesting.logger.debug(description)
-        perform
-        CaTesting.logger.info("Patch successfully added.")
-      end
-
+    class Sample < Base
       private
 
       def description
@@ -26,16 +16,8 @@ module CaTesting
         :change_some_behaviour
       end
 
-      def deprecate?
-        Time.new > deprecation_notice_date
-      end
-
       def deprecation_notice_date
         Time.new(2021, 2, 2)
-      end
-
-      def prevent_usage?
-        Time.new > prevent_usage_date
       end
 
       def prevent_usage_date

--- a/spec/ca_testing/patches/logger_spec.rb
+++ b/spec/ca_testing/patches/logger_spec.rb
@@ -1,22 +1,6 @@
 # frozen_string_literal: true
 RSpec.describe CaTesting::Patches::Logger do
   it_behaves_like "a patch" do
-    subject { described_class.new(fake_logger.new) }
-
-    let(:fake_logger) do
-      Class.new do
-        def initialize
-          @logdev = OpenStruct.new(dev: fake_log_device.new)
-        end
-
-        def fake_log_device
-          Struct.new(:foo) do
-            def set_encoding(*_args)
-              :bar
-            end
-          end
-        end
-      end
-    end
+    subject { described_class.new(double) }
   end
 end

--- a/spec/ca_testing/patches/logger_spec.rb
+++ b/spec/ca_testing/patches/logger_spec.rb
@@ -1,48 +1,10 @@
 # frozen_string_literal: true
 RSpec.describe CaTesting::Patches::Logger do
-  subject { described_class.new(CaTesting.logger) }
+  it_behaves_like "a patch" do
+    subject { described_class.new(CaTesting.logger) }
 
-  before do
-    CaTesting.logger.level = :UNKNOWN
-    allow(subject).to receive(:deprecate?).and_return(deprecate?)
-    allow(subject).to receive(:prevent_usage?).and_return(prevent_usage?)
-    allow(Kernel).to receive(:warn)
-  end
-
-  let(:deprecate?) { false }
-  let(:prevent_usage?) { false }
-
-  describe "#patch!" do
-    context "when permissible" do
-      it "performs the patch successfully" do
-        expect(subject).to receive(:perform)
-
-        subject.patch!
-      end
-    end
-
-    context "when deprecated" do
-      let(:deprecate?) { true }
-
-      it "performs the patch successfully" do
-        expect(subject).to receive(:perform)
-
-        subject.patch!
-      end
-
-      it "notifies the user that it is deprecated" do
-        expect(Kernel).to receive(:warn).with("This is now deprecated and should not be used")
-
-        subject.patch!
-      end
-    end
-
-    context "when EOL" do
-      let(:prevent_usage?) { true }
-
-      it "raises an Error" do
-        expect { subject.patch! }.to raise_error(RuntimeError).with_message("This is no longer supported")
-      end
+    before do
+      CaTesting.logger.level = :UNKNOWN
     end
   end
 end

--- a/spec/ca_testing/patches/logger_spec.rb
+++ b/spec/ca_testing/patches/logger_spec.rb
@@ -1,8 +1,22 @@
 # frozen_string_literal: true
 RSpec.describe CaTesting::Patches::Logger do
   it_behaves_like "a patch" do
-    subject { described_class.new(CaTesting.logger) }
+    subject { described_class.new(fake_logger.new) }
 
-    before { CaTesting.logger.level = :UNKNOWN }
+    let(:fake_logger) do
+      Class.new do
+        def initialize
+          @logdev = OpenStruct.new(dev: fake_log_device.new)
+        end
+
+        def fake_log_device
+          Struct.new(:foo) do
+            def set_encoding(*_args)
+              :bar
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/ca_testing/patches/logger_spec.rb
+++ b/spec/ca_testing/patches/logger_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+RSpec.describe CaTesting::Patches::Logger do
+  subject { described_class.new(CaTesting.logger) }
+
+  before do
+    CaTesting.logger.level = :UNKNOWN
+    allow(subject).to receive(:deprecate?).and_return(deprecate?)
+    allow(subject).to receive(:prevent_usage?).and_return(prevent_usage?)
+    allow(Kernel).to receive(:warn)
+  end
+
+  let(:deprecate?) { false }
+  let(:prevent_usage?) { false }
+
+  describe "#patch!" do
+    context "when permissible" do
+      it "performs the patch successfully" do
+        expect(subject).to receive(:perform)
+
+        subject.patch!
+      end
+    end
+
+    context "when deprecated" do
+      let(:deprecate?) { true }
+
+      it "performs the patch successfully" do
+        expect(subject).to receive(:perform)
+
+        subject.patch!
+      end
+
+      it "notifies the user that it is deprecated" do
+        expect(Kernel).to receive(:warn).with("This is now deprecated and should not be used")
+
+        subject.patch!
+      end
+    end
+
+    context "when EOL" do
+      let(:prevent_usage?) { true }
+
+      it "raises an Error" do
+        expect { subject.patch! }.to raise_error(RuntimeError).with_message("This is no longer supported")
+      end
+    end
+  end
+end

--- a/spec/ca_testing/patches/logger_spec.rb
+++ b/spec/ca_testing/patches/logger_spec.rb
@@ -3,8 +3,6 @@ RSpec.describe CaTesting::Patches::Logger do
   it_behaves_like "a patch" do
     subject { described_class.new(CaTesting.logger) }
 
-    before do
-      CaTesting.logger.level = :UNKNOWN
-    end
+    before { CaTesting.logger.level = :UNKNOWN }
   end
 end

--- a/spec/ca_testing/patches/sample_spec.rb
+++ b/spec/ca_testing/patches/sample_spec.rb
@@ -1,45 +1,4 @@
 # frozen_string_literal: true
 RSpec.describe CaTesting::Patches::Sample do
-  before do
-    allow(subject).to receive(:deprecate?).and_return(deprecate?)
-    allow(subject).to receive(:prevent_usage?).and_return(prevent_usage?)
-    allow(Kernel).to receive(:warn)
-  end
-
-  let(:deprecate?) { false }
-  let(:prevent_usage?) { false }
-
-  describe "#patch!" do
-    context "when permissible" do
-      it "performs the patch successfully" do
-        expect(subject).to receive(:perform)
-
-        subject.patch!
-      end
-    end
-
-    context "when deprecated" do
-      let(:deprecate?) { true }
-
-      it "performs the patch successfully" do
-        expect(subject).to receive(:perform)
-
-        subject.patch!
-      end
-
-      it "notifies the user that it is deprecated" do
-        expect(Kernel).to receive(:warn).with("This is now deprecated and should not be used")
-
-        subject.patch!
-      end
-    end
-
-    context "when EOL" do
-      let(:prevent_usage?) { true }
-
-      it "raises an Error" do
-        expect { subject.patch! }.to raise_error(RuntimeError).with_message("This is no longer supported")
-      end
-    end
-  end
+  it_behaves_like "a patch"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@ require "ca_testing"
 require "selenium-webdriver"
 require "capybara"
 
+Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
+
 def capture_stdout
   original_stdout = $stdout
   $stdout = StringIO.new

--- a/spec/support/shared_examples/patches.rb
+++ b/spec/support/shared_examples/patches.rb
@@ -1,0 +1,44 @@
+RSpec.shared_examples "a patch" do
+  before do
+    allow(subject).to receive(:deprecate?).and_return(deprecate?)
+    allow(subject).to receive(:prevent_usage?).and_return(prevent_usage?)
+    allow(Kernel).to receive(:warn)
+  end
+
+  let(:deprecate?) { false }
+  let(:prevent_usage?) { false }
+
+  describe "#patch!" do
+    context "when permissible" do
+      it "performs the patch successfully" do
+        expect(subject).to receive(:perform)
+
+        subject.patch!
+      end
+    end
+
+    context "when deprecated" do
+      let(:deprecate?) { true }
+
+      it "performs the patch successfully" do
+        expect(subject).to receive(:perform)
+
+        subject.patch!
+      end
+
+      it "notifies the user that it is deprecated" do
+        expect(Kernel).to receive(:warn).with("This is now deprecated and should not be used")
+
+        subject.patch!
+      end
+    end
+
+    context "when EOL" do
+      let(:prevent_usage?) { true }
+
+      it "raises an Error" do
+        expect { subject.patch! }.to raise_error(RuntimeError).with_message("This is no longer supported")
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/patches.rb
+++ b/spec/support/shared_examples/patches.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.shared_examples "a patch" do
   before do
     allow(subject).to receive(:deprecate?).and_return(deprecate?)


### PR DESCRIPTION
### Logger patch

- This fixes a bug where a huge amount of warnings are spammed when trying to run `IO.write` on something which has an Encoding mis-match. Part of this problem is I couldn't find a way of fixing the Logger to spawn on a different Encoding char-set (Short of changing the full Encoding char-set).
- To alleviate this, we simply change the char-set momentarily, patch the logger, then switch back

#### Extra refactors
- I've introduced shared examples as for every patch basically the tests will be (or should be), very similar / identical. Consequently, adding them should involve as little code as possible.
- There is a slight dependency in the tests on the Logger patch requiring an actual logger object (Or something close to a logger literal), so I just inject the default internal one with the messages set to off (:UNKNOWN level). I tried to find a way to mock it, but then the nesting with iVars became a nuisance! Any tips here greatly appreciated.