### PR TITLE
Feature/np 1468 Selenium Options Patch

### DIFF
--- a/lib/ca_testing/patches.rb
+++ b/lib/ca_testing/patches.rb
@@ -2,3 +2,4 @@
 require "ca_testing/patches/base"
 require "ca_testing/patches/logger"
 require "ca_testing/patches/sample"
+require "ca_testing/patches/selenium_options"

--- a/lib/ca_testing/patches/selenium_options.rb
+++ b/lib/ca_testing/patches/selenium_options.rb
@@ -22,7 +22,11 @@ module CaTesting
 
       def description
         <<~DESCRIPTION
-          TODO
+          This patch fixes an issue with Selenium4 not camelising the browser_name property
+          The issue is the driver, which is now fully W3C conformant expects `browserName`
+
+          See: https://github.com/SeleniumHQ/selenium/pull/8834 for more details/discussion including this fix
+          LH - Nov 2020
         DESCRIPTION
       end
 

--- a/lib/ca_testing/patches/selenium_options.rb
+++ b/lib/ca_testing/patches/selenium_options.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module CaTesting
+  module Patches
+    class SeleniumOptions < Base
+      def initialize(browser)
+        @browser = browser
+        super()
+      end
+
+      def patch!
+        return unless valid?
+
+        super
+      end
+
+      def valid?
+        %i[firefox safari].include?(@browser)
+      end
+
+      private
+
+      def description
+        <<~DESCRIPTION
+          TODO
+        DESCRIPTION
+      end
+
+      def perform
+        case @browser
+        when :firefox then Selenium::WebDriver::Firefox::Options.include CapabilitiesAsJsonFix
+        when :safari then Selenium::WebDriver::Safari::Options.include CapabilitiesAsJsonFix
+        end
+      end
+
+      def deprecation_notice_date
+        Time.new(2021, 12, 25)
+      end
+
+      def prevent_usage_date
+        Time.new(2022, 6, 30)
+      end
+    end
+
+    module CapabilitiesAsJsonFix
+      private
+
+      def generate_as_json(value, camelize_keys: true)
+        if value.is_a?(Hash)
+          value.each_with_object({}) do |(key, val), hash|
+            key = convert_json_key(key, camelize: camelize_keys)
+            hash[key] = generate_as_json(val, camelize_keys: key != "prefs")
+          end
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/spec/ca_testing/patches/selenium_options_spec.rb
+++ b/spec/ca_testing/patches/selenium_options_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+RSpec.describe CaTesting::Patches::SeleniumOptions do
+  context "with firefox" do
+    it_behaves_like "a patch" do
+      subject { described_class.new(:firefox) }
+    end
+  end
+
+  context "with safari" do
+    it_behaves_like "a patch" do
+      subject { described_class.new(:safari) }
+    end
+  end
+
+  context "with anything else" do
+    subject { described_class.new(:foo) }
+
+    it "does not perform the patch" do
+      expect(subject).not_to receive(:perform)
+
+      subject.patch!
+    end
+  end
+end


### PR DESCRIPTION
Transfering this patch from PW to CA_testing
This patch fixes an issue with Selenium4 not camelising the browser_name property.
