### PR TITLE
Feature/np 1468 Capybara - Safari w3c non-conformancy patch

### DIFF
--- a/lib/ca_testing/patches.rb
+++ b/lib/ca_testing/patches.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 require "ca_testing/patches/base"
+require "ca_testing/patches/capybara"
 require "ca_testing/patches/logger"
 require "ca_testing/patches/sample"

--- a/lib/ca_testing/patches/capybara.rb
+++ b/lib/ca_testing/patches/capybara.rb
@@ -7,27 +7,22 @@ module CaTesting
 
       def description
         <<~DESCRIPTION
-          TO DO
+          TODO
         DESCRIPTION
       end
 
       def perform
-        perform_safari_text_patch
-        perform_firefox_driver_patch
+        ::Capybara::Node::Element.prepend SafariTextPatch
       end
 
       def deprecate?
         false
       end
+    end
 
-      def perform_safari_text_patch
-        ::Capybara::Node::Element.prepend SafariTextPatch
-      end
-
-      module SafariTextPatch
-        def text(type = nil, normalize_ws: ::Capybara.default_normalize_ws)
-          super(type, normalize_ws: normalize_ws)
-        end
+    module SafariTextPatch
+      def text(type = nil, normalize_ws: ::Capybara.default_normalize_ws)
+        super(type, normalize_ws: normalize_ws)
       end
     end
   end

--- a/lib/ca_testing/patches/capybara.rb
+++ b/lib/ca_testing/patches/capybara.rb
@@ -7,7 +7,9 @@ module CaTesting
 
       def description
         <<~DESCRIPTION
-          TODO
+          This patch is necessary when using the Safari browser. There is a bug in the text method and capybara
+          maintainers aren't willing to fix because according to them 'safari should fix their driver'.
+          As such we need to use Module.prepend, to ensure the correct default value is being passed.
         DESCRIPTION
       end
 

--- a/lib/ca_testing/patches/capybara.rb
+++ b/lib/ca_testing/patches/capybara.rb
@@ -7,9 +7,9 @@ module CaTesting
 
       def description
         <<~DESCRIPTION
-          This patch is necessary when using the Safari browser. There is a bug in the text method and capybara
-          maintainers aren't willing to fix because according to them 'safari should fix their driver'.
-          As such we need to use Module.prepend, to ensure the correct default value is being passed.
+          There is a bug in the #text method as Safari's w3c conformant endpoint isn't w3c conformant.
+
+          See https://github.com/teamcapybara/capybara/issues/2213 for more details.
         DESCRIPTION
       end
 

--- a/lib/ca_testing/patches/capybara.rb
+++ b/lib/ca_testing/patches/capybara.rb
@@ -12,17 +12,22 @@ module CaTesting
       end
 
       def perform
-        ::Capybara::Node::Element.prepend SafariTextPatch
+        perform_safari_text_patch
+        perform_firefox_driver_patch
       end
 
       def deprecate?
         false
       end
-    end
 
-    module SafariTextPatch
-      def text(type = nil, normalize_ws: ::Capybara.default_normalize_ws)
-        super(type, normalize_ws: normalize_ws)
+      def perform_safari_text_patch
+        ::Capybara::Node::Element.prepend SafariTextPatch
+      end
+
+      module SafariTextPatch
+        def text(type = nil, normalize_ws: ::Capybara.default_normalize_ws)
+          super(type, normalize_ws: normalize_ws)
+        end
       end
     end
   end

--- a/lib/ca_testing/patches/capybara.rb
+++ b/lib/ca_testing/patches/capybara.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module CaTesting
+  module Patches
+    class Capybara < Base
+      private
+
+      def description
+        <<~DESCRIPTION
+          TO DO
+        DESCRIPTION
+      end
+
+      def perform
+        ::Capybara::Node::Element.prepend SafariTextPatch
+      end
+
+      def deprecate?
+        false
+      end
+    end
+
+    module SafariTextPatch
+      def text(type = nil, normalize_ws: ::Capybara.default_normalize_ws)
+        super(type, normalize_ws: normalize_ws)
+      end
+    end
+  end
+end

--- a/spec/ca_testing/patches/capybara_spec.rb
+++ b/spec/ca_testing/patches/capybara_spec.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+RSpec.describe CaTesting::Patches::Capybara do
+  it_behaves_like "a patch"
+end


### PR DESCRIPTION
Transfering this patch from PW to CA_testing
This patch fixes an issue with Capybara text method not working properly for Safari Browser