### PR TITLE
refactor/lighten options class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 ## <sub>main</sub>
 #### _N/A_
 
+**Breaking Changes**
+* Options class refactors
+  * Now is no longer directly instantiated -> `Options.new(browser)` becomes `Options.for(browser)`
+  * Removed a few lines of redundant code that was duplicating some effort
+
+**Bugfixes**
+  * Fixed an issue where requiring just the local v4 driver wouldn't work due to not `require`ing selenium capabilities
+
 ## <sub>v1.1</sub>
 #### _May. 4, 2021_
 

--- a/lib/ca_testing/drivers.rb
+++ b/lib/ca_testing/drivers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "selenium/webdriver/remote"
+
 require "ca_testing/drivers/local"
 require "ca_testing/drivers/remote"
 require "ca_testing/drivers/v4"

--- a/lib/ca_testing/drivers/v4.rb
+++ b/lib/ca_testing/drivers/v4.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
+require "selenium/webdriver/remote"
+
 require "ca_testing/drivers/v4/local"
 require "ca_testing/drivers/v4/remote"

--- a/lib/ca_testing/drivers/v4/local.rb
+++ b/lib/ca_testing/drivers/v4/local.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "selenium/webdriver/remote"
+
 require "ca_testing/drivers/v4/options"
 
 module CaTesting

--- a/lib/ca_testing/drivers/v4/local.rb
+++ b/lib/ca_testing/drivers/v4/local.rb
@@ -65,7 +65,7 @@ module CaTesting
         end
 
         def options
-          Options.new(browser).options
+          Options.for(browser)
         end
 
         def safari?

--- a/lib/ca_testing/drivers/v4/options.rb
+++ b/lib/ca_testing/drivers/v4/options.rb
@@ -4,74 +4,44 @@ module CaTesting
   module Drivers
     module V4
       class Options
-        attr_reader :browser
-        private :browser
-
-        def self.for(browser)
-          case browser
-          when :chrome;             then ::Selenium::WebDriver::Chrome::Options.new
-          when :firefox;            then ::Selenium::WebDriver::Firefox::Options.new(log_level: "trace")
-          when :edge;               then ::Selenium::WebDriver::Edge::Options.new
-          when :safari;             then ::Selenium::WebDriver::Safari::Options.new(automatic_inspection: true)
-          when :internet_explorer;  then internet_explorer_options
-          else {}
+        class << self
+          def for(browser)
+            initial_options(browser).tap { |opts| opts.headless! if headless? }
           end
-        end
 
-        def initialize(browser)
-          @browser = browser
-        end
+          private
 
-        def options
-          send("#{browser}_options").tap { |opts| opts.headless! if headless? }
-        end
-
-        private
-
-        def chrome_options
-          ::Selenium::WebDriver::Chrome::Options.new
-        end
-
-        # Constantly fire mouseOver events on click actions (Should help mitigate flaky clicks)
-        def self.internet_explorer_options
-          ::Selenium::WebDriver::IE::Options.new(persistent_hover: true).tap do |opts|
-            # This is needed to mitigate a Selenium4/Browserstack issue whereby in Se4
-            # we combine Browser options and Capabilities and merge them. But for some
-            # reason Browserstack insist on giving `internet_explorer` a non-conformant
-            # name `IE`. This then causes huge issues in trying to find a browser that
-            # would match using firstMatch in 2 different ways.
-            #
-            # A Support ticket has been raised with Browserstack to see if they can fix
-            # anything at their end, as this is a bug with their matching protocols
-            # LH - Aug 2020
-            CaTesting.logger.info("Removing `browser_name` key from options payload.")
-            opts.options.delete(:browser_name)
+          def initial_options(browser)
+            case browser
+            when :chrome;             then ::Selenium::WebDriver::Chrome::Options.new
+            when :firefox;            then ::Selenium::WebDriver::Firefox::Options.new(log_level: "trace")
+            when :edge;               then ::Selenium::WebDriver::Edge::Options.new
+            when :safari;             then ::Selenium::WebDriver::Safari::Options.new(automatic_inspection: true)
+            when :internet_explorer;  then internet_explorer_options
+            else {}
+            end
           end
-        end
 
-        def firefox_options
-          ::Selenium::WebDriver::Firefox::Options.new(log_level: "trace")
-        end
+          # Constantly fire mouseOver events on click actions (Should help mitigate flaky clicks)
+          def internet_explorer_options
+            ::Selenium::WebDriver::IE::Options.new(persistent_hover: true).tap do |opts|
+              # This is needed to mitigate a Selenium4/Browserstack issue whereby in Se4
+              # we combine Browser options and Capabilities and merge them. But for some
+              # reason Browserstack insist on giving `internet_explorer` a non-conformant
+              # name `IE`. This then causes huge issues in trying to find a browser that
+              # would match using firstMatch in 2 different ways.
+              #
+              # A Support ticket has been raised with Browserstack to see if they can fix
+              # anything at their end, as this is a bug with their matching protocols
+              # LH - Aug 2020
+              CaTesting.logger.info("Removing `browser_name` key from options payload.")
+              opts.options.delete(:browser_name)
+            end
+          end
 
-        def edge_options
-          ::Selenium::WebDriver::Edge::Options.new
-        end
-
-        # Preload Web Inspector and JavaScript debugger
-        def safari_options
-          ::Selenium::WebDriver::Safari::Options.new(automatic_inspection: true)
-        end
-
-        def android_options
-          {}
-        end
-
-        def ios_options
-          {}
-        end
-
-        def headless?
-          ENV["HEADLESS"] == "true"
+          def headless?
+            ENV["HEADLESS"] == "true"
+          end
         end
       end
     end

--- a/lib/ca_testing/drivers/v4/options.rb
+++ b/lib/ca_testing/drivers/v4/options.rb
@@ -7,6 +7,17 @@ module CaTesting
         attr_reader :browser
         private :browser
 
+        def self.for(browser)
+          case browser
+          when :chrome;             then ::Selenium::WebDriver::Chrome::Options.new
+          when :firefox;            then ::Selenium::WebDriver::Firefox::Options.new(log_level: "trace")
+          when :edge;               then ::Selenium::WebDriver::Edge::Options.new
+          when :safari;             then ::Selenium::WebDriver::Safari::Options.new(automatic_inspection: true)
+          when :internet_explorer;  then internet_explorer_options
+          else {}
+          end
+        end
+
         def initialize(browser)
           @browser = browser
         end
@@ -22,7 +33,7 @@ module CaTesting
         end
 
         # Constantly fire mouseOver events on click actions (Should help mitigate flaky clicks)
-        def internet_explorer_options
+        def self.internet_explorer_options
           ::Selenium::WebDriver::IE::Options.new(persistent_hover: true).tap do |opts|
             # This is needed to mitigate a Selenium4/Browserstack issue whereby in Se4
             # we combine Browser options and Capabilities and merge them. But for some

--- a/lib/ca_testing/drivers/v4/remote.rb
+++ b/lib/ca_testing/drivers/v4/remote.rb
@@ -36,7 +36,7 @@ module CaTesting
         end
 
         def options
-          Options.new(browser).options
+          Options.for(browser)
         end
 
         def hub_url

--- a/lib/ca_testing/drivers/v4/remote.rb
+++ b/lib/ca_testing/drivers/v4/remote.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require "ca_testing/drivers/v4/options"
 require "selenium/webdriver/remote"
+
+require "ca_testing/drivers/v4/options"
 
 module CaTesting
   module Drivers

--- a/spec/ca_testing/drivers/v4/local_spec.rb
+++ b/spec/ca_testing/drivers/v4/local_spec.rb
@@ -101,13 +101,5 @@ RSpec.describe CaTesting::Drivers::V4::Local do
           )
       end
     end
-
-    context "for an unsupported browser" do
-      let(:browser) { :foo }
-
-      it "doesn't work if the browser is not one of the supported browsers" do
-        expect { options }.to raise_error(NoMethodError)
-      end
-    end
   end
 end

--- a/spec/ca_testing/drivers/v4/local_spec.rb
+++ b/spec/ca_testing/drivers/v4/local_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe CaTesting::Drivers::V4::Local do
     context "for safari" do
       let(:browser) { :safari }
 
-      # Prevent Docker container complaining it doesn't know where safari is!
+      # Prevent OS complaining it doesn't know where safari is!
       before { allow(Selenium::WebDriver::Platform).to receive(:assert_executable) }
 
       it "has correct top level properties" do

--- a/spec/ca_testing/drivers/v4/options_spec.rb
+++ b/spec/ca_testing/drivers/v4/options_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe CaTesting::Drivers::V4::Options do
       it { is_expected.to have_attributes({ browser_name: "safari", automatic_inspection: true }) }
     end
 
+    context "when requesting a headless browser" do
+      before { allow(described_class).to receive(:headless?) { true } }
+
+      let(:browser) { :chrome }
+
+      it { is_expected.to have_attributes({ args: ["--headless"] }) }
+    end
+
     context "for any other browser" do
       let(:browser) { :foo }
 

--- a/spec/ca_testing/drivers/v4/options_spec.rb
+++ b/spec/ca_testing/drivers/v4/options_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe CaTesting::Drivers::V4::Options do
-  describe "#options" do
-    subject(:options) { described_class.new(browser).options }
+  describe ".for" do
+    subject(:options) { described_class.for(browser) }
 
     context "for chrome" do
       let(:browser) { :chrome }
@@ -28,24 +28,10 @@ RSpec.describe CaTesting::Drivers::V4::Options do
       it { is_expected.to have_attributes({ browser_name: "safari", automatic_inspection: true }) }
     end
 
-    context "for ios" do
-      let(:browser) { :ios }
-
-      it { is_expected.to be_empty }
-    end
-
-    context "for android" do
-      let(:browser) { :android }
-
-      it { is_expected.to be_empty }
-    end
-
-    context "for an unsupported browser" do
+    context "for any other browser" do
       let(:browser) { :foo }
 
-      it "doesn't work if the browser is not one of the supported browsers" do
-        expect { subject }.to raise_error(NoMethodError)
-      end
+      it { is_expected.to be_empty }
     end
   end
 end


### PR DESCRIPTION
Refactors:
- The Options class was previously a bit bulkier. We now have something about 20% less code and doing the same functionality.
- It also covers us against any new types of browser option instead of having to write them all as blank hashes.
- Don't create excess objects that just return hashes immediately and then need GC'ing

Bugfixes:
- Allow individual drivers to be created (Previously only requiring the local driver because it needs the "poorly named" `remote/capabilities` file from the selenium gem. So this is now added recursively down the tree.
- Add test for headless browsers returning correct options cmd line switch (Previously missing)

NB: Whilst Options was technically not fully public, I'll release this as a major version (Gonna stick in some other changes first too)