### PR TITLE
bugfix: Missing Device Name permeability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
-## <sub>main</sub>
-#### _N/A_
+## <sub>v2.0.1</sub>
+#### _Jun. 18, 2021_
+
+**Bugfixes**
+* Fixed ios capabilities to accept a device name as well as an ios version
+
+## <sub>v2.0</sub>
+#### _Jun. 17, 2021_
 
 **Breaking Changes**
 * Options class refactors

--- a/lib/ca_testing/drivers/v4/browserstack/ios.rb
+++ b/lib/ca_testing/drivers/v4/browserstack/ios.rb
@@ -5,10 +5,11 @@ module CaTesting
     module V4
       module Browserstack
         class Ios
-          attr_reader :ios_version
-          private :ios_version
+          attr_reader :device_name, :ios_version
+          private :device_name, :ios_version
 
-          def initialize(ios_version)
+          def initialize(device_name, ios_version)
+            @device_name = device_name
             @ios_version = ios_version
           end
 
@@ -18,7 +19,7 @@ module CaTesting
           def capabilities
             {
               "bstack:options" => {
-                "deviceName" => "ios",
+                "deviceName" => device_name,
                 "realMobile" => "true",
                 "appiumVersion" => appium_version
               }

--- a/lib/ca_testing/version.rb
+++ b/lib/ca_testing/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CaTesting
-  VERSION = "2.0"
+  VERSION = "2.0.1"
 end

--- a/spec/ca_testing/drivers/v4/browserstack/ios_spec.rb
+++ b/spec/ca_testing/drivers/v4/browserstack/ios_spec.rb
@@ -1,30 +1,31 @@
 # frozen_string_literal: true
 
 RSpec.describe CaTesting::Drivers::V4::Browserstack::Ios do
-  subject(:capabilities) { described_class.new(appium_version).capabilities }
+  subject(:capabilities) { described_class.new(device_name, ios_version).capabilities }
+
+  let(:ios_version) { "12" }
+  let(:device_name) { "iPhone11" }
 
   describe "#capabilities" do
-    context "with a valid appium version" do
-      let(:appium_version) { "12" }
-
+    context "with a valid device / iOS version" do
       it "has correct ios capabilities" do
         expect(capabilities).to eq(
           {
             "bstack:options" => {
-              "deviceName" => "ios",
+              "deviceName" => "iPhone11",
               "realMobile" => "true",
               "appiumVersion" => "1.19.1"
             }
           }
         )
       end
+    end
 
-      context "with an invalid appium version" do
-        let(:appium_version) { "10" }
+    context "with an invalid iOS version" do
+      let(:ios_version) { "10" }
 
-        it "it complains ios version is invalid" do
-          expect { capabilities }.to raise_error(ArgumentError)
-        end
+      it "it complains that the iOS version is invalid" do
+        expect { capabilities }.to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
I keep forgetting little nuances, and Browserstack pass in the device name into the bstack options, not into the top level bit (Which isn't yet migrated)