### PR TITLE
Feature/add stale boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## <sub>main</sub>
+#### _Unreleased_
+
+**New**
+* Added extension for `Capybara::Node::Element#stale?`
+
 ## <sub>v2.0.1</sub>
 #### _Jun. 18, 2021_
 

--- a/lib/ca_testing/extensions/capybara/node/element.rb
+++ b/lib/ca_testing/extensions/capybara/node/element.rb
@@ -16,6 +16,13 @@ module Capybara
       def vertical_position
         native.rect.y.to_i
       end
+
+      # @return [Boolean]
+      #
+      # Whether the element is in a stale state or not
+      def stale?
+        self.inspect == "Obsolete #<Capybara::Node::Element>"
+      end
     end
   end
 end

--- a/lib/ca_testing/extensions/capybara/node/element.rb
+++ b/lib/ca_testing/extensions/capybara/node/element.rb
@@ -21,7 +21,7 @@ module Capybara
       #
       # Whether the element is in a stale state or not
       def stale?
-        self.inspect == "Obsolete #<Capybara::Node::Element>"
+        inspect == "Obsolete #<Capybara::Node::Element>"
       end
     end
   end

--- a/spec/ca_testing/extensions/capybara/node/element_spec.rb
+++ b/spec/ca_testing/extensions/capybara/node/element_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 describe Capybara::Node::Element do
-  subject(:capybara_element) { described_class.new(:_session, :_base, :_query_scope, :_query) }
-  let(:selenium_element) { double(rect: rect) }
-  let(:rect) { instance_double(Selenium::WebDriver::Rectangle, { x: 8, y: 29, width: 185, height: 21 }) }
+  before { session.visit('/sample_page.html') }
 
-  before { allow(capybara_element).to receive(:native).and_return(selenium_element) }
+  subject(:capybara_element) { session.find(".embedded_element") }
+  let(:session) { Capybara::Session.new(:selenium_chrome_headless) }
 
   describe "#horizontal_position" do
     it "returns the top-left horizontal ordinate from the native rect" do
@@ -16,6 +15,21 @@ describe Capybara::Node::Element do
   describe "#vertical_position" do
     it "returns the top-left vertical ordinate from the native rect" do
       expect(capybara_element.vertical_position).to eq(29)
+    end
+  end
+
+  describe "#stale?" do
+    context "when not stale" do
+      it { is_expected.not_to be_stale }
+    end
+
+    context "when made stale" do
+      it "returns true" do
+        cached_element = capybara_element
+        session.find("#remove_container").click
+
+        expect(cached_element).to be_stale
+      end
     end
   end
 end

--- a/spec/ca_testing/extensions/capybara/node/element_spec.rb
+++ b/spec/ca_testing/extensions/capybara/node/element_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Capybara::Node::Element do
-  before { session.visit('/sample_page.html') }
+  before { session.visit("/sample_page.html") }
 
   subject(:capybara_element) { session.find(".embedded_element") }
   let(:session) { Capybara::Session.new(:selenium_chrome_headless) }

--- a/spec/ca_testing/extensions/capybara/node/element_spec.rb
+++ b/spec/ca_testing/extensions/capybara/node/element_spec.rb
@@ -14,7 +14,7 @@ describe Capybara::Node::Element do
 
   describe "#vertical_position" do
     it "returns the top-left vertical ordinate from the native rect" do
-      expect(capybara_element.vertical_position).to eq(29)
+      expect(capybara_element.vertical_position).to eq(169)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 
 Capybara.configure do |config|
   config.app_host = "file://#{File.dirname(__FILE__)}/support/fixtures"
+  config.default_max_wait_time = 0
 end
 
 CaTesting.configure do |config|

--- a/spec/support/fixtures/sample_page.html
+++ b/spec/support/fixtures/sample_page.html
@@ -1,12 +1,23 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
+  <head>
     <title>Hello!</title>
+    <script type="text/javascript">
+      function removeElement(node) {
+        node.parentNode.removeChild(node);
+      }
+    </script>
     <meta charset="utf-8">
-	</head>
-	<body>
-    <input type="text"/>
+  </head>
+  <body>
     <textarea></textarea>
     <div contenteditable="true" style="height: 100px"></div>
-	</body>
+
+    <input type="submit" id="remove_container" onClick='removeElement(document.getElementById("container"))'/>
+    <div id="container">
+      <div class="embedded_element">
+        This will be removed when you click submit above
+      </div>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
This allows us to (rudimentarily), detect if a CNE is stale.

We do this by interrogating the catch all string that Capybara returns. This is very useful in a nested POM structure such as site_prism, whereby we can then find out that if our recursion is failing because of our parent (or it's parent), being stale, we can just reload all appropriate parent/s