### PR TITLE
Feature/add browserstack base driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 **New**
 * Added extension for `Capybara::Node::Element#stale?`
 
+* Added Browserstack Base driver (capabilities / options)
+
 ## <sub>v2.0.1</sub>
 #### _Jun. 18, 2021_
 

--- a/ca_testing.gemspec
+++ b/ca_testing.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "faraday", "~> 1.0"
+
   spec.add_development_dependency "capybara", "~> 3.8"
   spec.add_development_dependency "cucumber", [">= 5.0", "< 7"]
   spec.add_development_dependency "rake", "~> 13.0"

--- a/lib/ca_testing/drivers/v4/browserstack.rb
+++ b/lib/ca_testing/drivers/v4/browserstack.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 require "ca_testing/drivers/v4/browserstack/android"
+require "ca_testing/drivers/v4/browserstack/base"
 require "ca_testing/drivers/v4/browserstack/chrome"
 require "ca_testing/drivers/v4/browserstack/ios"

--- a/lib/ca_testing/drivers/v4/browserstack/base.rb
+++ b/lib/ca_testing/drivers/v4/browserstack/base.rb
@@ -5,6 +5,9 @@ module CaTesting
     module V4
       module Browserstack
         class Base
+          #
+          # api private (Not intended to be instantiated directly!)
+          #
           attr_reader :browser, :browserstack_options
           private :browser, :browserstack_options
 

--- a/lib/ca_testing/drivers/v4/browserstack/base.rb
+++ b/lib/ca_testing/drivers/v4/browserstack/base.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module CaTesting
+  module Drivers
+    module V4
+      module Browserstack
+        class Base
+          include Helpers::EnvVariables
+
+          def register
+            Capybara.register_driver :selenium do |app|
+              Capybara::Selenium::Driver.new(
+                app,
+                browser: :remote,
+                capabilities: [desired_capabilities, options],
+                url: browserstack_hub_url
+              )
+            end
+          end
+
+          private
+
+          def desired_capabilities
+            Selenium::WebDriver::Remote::Capabilities.new(
+              Faraday::Utils.deep_merge(standard_capabilities, specific_browser_capabilities)
+            )
+          end
+
+          def standard_capabilities
+            standard_browserstack_capabilities.merge(browser_version)
+          end
+
+          def specific_browser_capabilities
+            {}
+          end
+
+          def browser_version
+            if device?
+              {}
+            else
+              { "browserVersion" => browserstack_browser_version }
+            end
+          end
+
+          def standard_browserstack_capabilities
+            {
+              "bstack:options" => {
+                "buildName" => build_name,
+                "projectName" => "Public-Website tests",
+                "sessionName" => session_name,
+                "os" => browserstack_os,
+                "osVersion" => browserstack_os_version,
+                "local" => "false",
+                "seleniumVersion" => selenium_jar_version,
+                "debug" => browserstack_debug_mode,
+                "consoleLogs" => "verbose",
+                "networkLogs" => "true",
+                "resolution" => "1920x1080"
+              }
+            }
+          end
+
+          def options
+            CaTesting::Drivers::V4::Options.for(browser)
+          end
+
+          def browserstack_hub_url
+            "https://#{browserstack_username}:#{browserstack_api_key}@hub-cloud.browserstack.com/wd/hub"
+          end
+
+          def build_name
+            PayloadValuesGenerator.build_name
+          end
+
+          def session_name
+            PayloadValuesGenerator.session_name
+          end
+
+          def selenium_jar_version
+            "4.0.0-alpha-6"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ca_testing/drivers/v4/browserstack/base.rb
+++ b/lib/ca_testing/drivers/v4/browserstack/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "faraday"
+
 module CaTesting
   module Drivers
     module V4
@@ -35,7 +37,7 @@ module CaTesting
 
           def desired_capabilities
             Selenium::WebDriver::Remote::Capabilities.new(
-              Faraday::Utils.deep_merge(
+              ::Faraday::Utils.deep_merge(
                 # Browserstack Capabilities and General Capabilities are at different levels, so we merge first
                 browserstack_capabilities.merge(browser_version_capability),
                 # Then we deep merge with anything specifically passed into the driver registration (as these can be nested)
@@ -45,7 +47,7 @@ module CaTesting
           end
 
           def browserstack_capabilities
-            Faraday::Utils.deep_merge(configurable_capabilities, static_capabilities)
+            ::Faraday::Utils.deep_merge(configurable_capabilities, static_capabilities)
           end
 
           def configurable_capabilities

--- a/lib/ca_testing/drivers/v4/browserstack/base.rb
+++ b/lib/ca_testing/drivers/v4/browserstack/base.rb
@@ -8,12 +8,13 @@ module CaTesting
           #
           # api private (Not intended to be instantiated directly!)
           #
-          attr_reader :browser, :browserstack_options
-          private :browser, :browserstack_options
+          attr_reader :browser, :browserstack_options, :defined_capabilities
+          private :browser, :browserstack_options, :defined_capabilities
 
-          def initialize(browser, browserstack_options)
+          def initialize(browser, browserstack_options, defined_capabilities = nil)
             @browser = browser
             @browserstack_options = browserstack_options
+            @defined_capabilities = defined_capabilities
           end
 
           # @return [Nil]
@@ -79,11 +80,7 @@ module CaTesting
           end
 
           def specific_browser_capabilities
-            if defined?(capabilities)
-              capabilities
-            else
-              {}
-            end
+            defined_capabilities || {}
           end
 
           def options

--- a/lib/ca_testing/drivers/v4/browserstack/base.rb
+++ b/lib/ca_testing/drivers/v4/browserstack/base.rb
@@ -5,8 +5,6 @@ module CaTesting
     module V4
       module Browserstack
         class Base
-          include Helpers::EnvVariables
-
           attr_reader :browser, :browserstack_options
           private :browser, :browserstack_options
 
@@ -30,16 +28,29 @@ module CaTesting
 
           def desired_capabilities
             Selenium::WebDriver::Remote::Capabilities.new(
-              Faraday::Utils.deep_merge(standard_capabilities, specific_browser_capabilities)
+              Faraday::Utils.deep_merge(
+                standard_browserstack_capabilities.merge(general_browser_capabilities),
+                specific_browser_capabilities
+              )
             )
           end
 
-          def standard_capabilities
-            standard_browserstack_capabilities.merge(general_browser_capabilities)
-          end
-
-          def specific_browser_capabilities
-            {}
+          def standard_browserstack_capabilities
+            {
+              "bstack:options" => {
+                "buildName" => browserstack_options[:build_name],
+                "projectName" => browserstack_options[:project_name],
+                "sessionName" => browserstack_options[:session_name],
+                "debug" => browserstack_options[:browserstack_debug_mode],
+                "os" => os,
+                "osVersion" => os_version,
+                "local" => "false",
+                "seleniumVersion" => "4.0.0-alpha-6",
+                "consoleLogs" => "verbose",
+                "networkLogs" => "true",
+                "resolution" => "1920x1080"
+              }
+            }
           end
 
           def general_browser_capabilities
@@ -48,22 +59,8 @@ module CaTesting
             { "browserVersion" => browser_version }
           end
 
-          def standard_browserstack_capabilities
-            {
-              "bstack:options" => {
-                "buildName" => browserstack_options[:build_name],
-                "projectName" => "Public-Website tests",
-                "sessionName" => browserstack_options[:session_name],
-                "os" => os,
-                "osVersion" => os_version,
-                "local" => "false",
-                "seleniumVersion" => "4.0.0-alpha-6",
-                "debug" => browserstack_options[:browserstack_debug_mode],
-                "consoleLogs" => "verbose",
-                "networkLogs" => "true",
-                "resolution" => "1920x1080"
-              }
-            }
+          def specific_browser_capabilities
+            {}
           end
 
           def options

--- a/lib/ca_testing/drivers/v4/browserstack/base.rb
+++ b/lib/ca_testing/drivers/v4/browserstack/base.rb
@@ -7,9 +7,6 @@ module CaTesting
     module V4
       module Browserstack
         class Base
-          #
-          # api private (Not intended to be instantiated directly!)
-          #
           attr_reader :browser, :browserstack_options, :custom_capabilities
           private :browser, :browserstack_options, :custom_capabilities
 

--- a/lib/ca_testing/drivers/v4/browserstack/base.rb
+++ b/lib/ca_testing/drivers/v4/browserstack/base.rb
@@ -79,7 +79,11 @@ module CaTesting
           end
 
           def specific_browser_capabilities
-            {}
+            if defined?(capabilities)
+              capabilities
+            else
+              {}
+            end
           end
 
           def options

--- a/lib/ca_testing/drivers/v4/remote.rb
+++ b/lib/ca_testing/drivers/v4/remote.rb
@@ -17,7 +17,7 @@ module CaTesting
 
         # @return [Nil]
         #
-        # Register a new driver with the default selenium name for use in a local grid setup
+        # Register a new driver with the default selenium name for use in a (localised), remote grid setup
         def register
           Capybara.register_driver :selenium do |app|
             Capybara::Selenium::Driver.new(

--- a/spec/ca_testing/drivers/v4/browserstack/base_spec.rb
+++ b/spec/ca_testing/drivers/v4/browserstack/base_spec.rb
@@ -49,5 +49,9 @@ RSpec.describe CaTesting::Drivers::V4::Browserstack::Base do
           }
         )
     end
+
+    it "sets the hub url using the browserstack credentials" do
+      expect(options[:url]).to eq("https://username:apikey123@hub-cloud.browserstack.com/wd/hub")
+    end
   end
 end

--- a/spec/ca_testing/drivers/v4/browserstack/base_spec.rb
+++ b/spec/ca_testing/drivers/v4/browserstack/base_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe CaTesting::Drivers::V4::Browserstack::Base do
+  before do
+    Capybara.default_driver = :selenium
+    described_class.new(browser, browserstack_options).register
+  end
+
+  after(:each) { session.quit }
+
+  subject(:options) { session.driver.options }
+
+  let(:session) { Capybara::Session.new(:selenium) }
+  let(:browserstack_options) do
+    {
+      build_name: "build",
+      project_name: "project",
+      session_name: "session",
+      browserstack_debug_mode: "false",
+      username: "username",
+      api_key: "apikey123",
+      config: "os_osversionnumber_browserversionnumber"
+    }
+  end
+  let(:caps) { options[:capabilities].first.as_json }
+
+  describe "#register" do
+    let(:browser) { :foo }
+
+    it "has correct desired capabilities" do
+      expect(caps)
+        .to eq(
+          {
+            "bstack:options" =>
+              {
+                "buildName" => "build",
+                "projectName" => "project",
+                "sessionName" => "session",
+                "debug" => "false",
+                "os" => "os",
+                "osVersion" => "osversionnumber",
+                "local" => "false",
+                "seleniumVersion" => "4.0.0-alpha-6",
+                "consoleLogs" => "verbose",
+                "networkLogs" => "true",
+                "resolution" => "1920x1080"
+              },
+            "browserVersion" => "browserversionnumber"
+          }
+        )
+    end
+  end
+end


### PR DESCRIPTION
This adds the base browserstack driver to the repo (Again removing a bunch of duplicate code).

However because this is something which **will** require partial configuration at the user side, we've split the creation to take 3 arguments.

The browser like always is mandatory, as are the browserstack options that we pass in (For things like build name e.t.c.), However to further tidy things up. Instead of having a non-overridden base class which will then pass in a blank hash, we can just default to a blank hash (So any default drivers without special args don't need a third argument).