### PR TITLE
Feature/parallel cucumber patch

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,10 @@
 inherit_gem:
   citizens-advice-style:
     - default.yml
+
+AllCops:
+  Exclude:
+    # This patch is 80% copied code from the upstream repo. As such there are different style
+    - 'lib/ca_testing/patches/parallel_cucumber.rb'
+    # This needs fixing in the gem proper
+    - 'vendor/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "citizens-advice-style", github: "citizensadvice/citizens-advice-style-ruby", tag: "v2.1.0"
+gem "citizens-advice-style", github: "citizensadvice/citizens-advice-style-ruby", tag: "v3.0.0"
 
 gemspec

--- a/ca_testing.gemspec
+++ b/ca_testing.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faraday", "~> 1.0"
 
   spec.add_development_dependency "capybara", "~> 3.8"
-  spec.add_development_dependency "cucumber", [">= 5.0", "< 7"]
+  spec.add_development_dependency "cucumber", [">= 5.0", "< 8"]
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.10"
   spec.add_development_dependency "selenium-webdriver", [">= 4.0.0.alpha1", "< 4.1"]

--- a/ca_testing.gemspec
+++ b/ca_testing.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "capybara", "~> 3.8"
   spec.add_development_dependency "cucumber", [">= 5.0", "< 8"]
+  spec.add_development_dependency "parallel_tests", "~> 3.7"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.10"
   spec.add_development_dependency "selenium-webdriver", [">= 4.0.0.alpha1", "< 4.1"]

--- a/lib/ca_testing/patches.rb
+++ b/lib/ca_testing/patches.rb
@@ -2,6 +2,7 @@
 
 require "ca_testing/patches/base"
 require "ca_testing/patches/capybara"
+require "ca_testing/patches/parallel_cucumber"
 require "ca_testing/patches/selenium_logger"
 require "ca_testing/patches/selenium_manager"
 require "ca_testing/patches/selenium_options"

--- a/lib/ca_testing/patches/parallel_cucumber.rb
+++ b/lib/ca_testing/patches/parallel_cucumber.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module CaTesting
+  module Patches
+    class ParallelCucumber < Base
+      private
+
+      def description
+        <<~DESCRIPTION
+          This patch fixes an issue where the parallel tests gem won't place the --retry flag in the correct
+          position for command invocation with cucumber
+          See: https://github.com/grosser/parallel_tests/pull/827 for more details/discussion including this fix
+        DESCRIPTION
+      end
+
+      def perform
+        ::ParallelTests::Gherkin::Runner.extend RetryFlagFix
+      end
+
+      def deprecation_notice_date
+        Time.new(2022, 6, 30)
+      end
+
+      def prevent_usage_date
+        Time.new(2022, 12, 25)
+      end
+    end
+
+    module RetryFlagFix
+      def run_tests(test_files, process_number, num_processes, options)
+        # Copied Code - https://github.com/grosser/parallel_tests/blob/master/lib/parallel_tests/gherkin/runner.rb#L9
+        combined_scenarios = test_files
+
+        if options[:group_by] == :scenarios
+          grouped = test_files.map { |t| t.split(':') }.group_by(&:first)
+          combined_scenarios = grouped.map do |file, files_and_lines|
+            "#{file}:#{files_and_lines.map(&:last).join(':')}"
+          end
+        end
+
+        sanitized_test_files = combined_scenarios.map { |val| WINDOWS ? "\"#{val}\"" : Shellwords.escape(val) }
+
+        options[:env] ||= {}
+        options[:env] = options[:env].merge({ 'AUTOTEST' => '1' }) if $stdout.tty?
+
+        # New code
+        opts = cucumber_opts(options[:test_options])
+        cmd = [
+          executable,
+          (runtime_logging if File.directory?(File.dirname(runtime_log))),
+          opts[0],
+          *sanitized_test_files,
+          opts[1]
+        ].compact.reject(&:empty?).join(' ')
+        execute_command(cmd, process_number, num_processes, options)
+      end
+
+      def cucumber_opts(given)
+        # All new code
+        initial =
+          if given =~ (/--profile/) || given =~ (/(^|\s)-p /)
+            given
+          else
+            [given, profile_from_config].compact.join(" ")
+          end
+
+        opts_as_individuals = initial.scan(/\S+\s\S+/)
+        desired_output = ['', '']
+
+        opts_as_individuals.each do |opt|
+          if opt.match?(/--retry \d+/)
+            desired_output[1] = opt
+          else
+            desired_output[0] = "#{desired_output[0]} #{opt}".strip
+          end
+        end
+
+        desired_output
+      end
+    end
+  end
+end

--- a/spec/ca_testing/patches/parallel_cucumber_spec.rb
+++ b/spec/ca_testing/patches/parallel_cucumber_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe CaTesting::Patches::ParallelCucumber do
+  it_behaves_like "a patch"
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require "capybara"
 require "capybara/dsl"
 require "webdrivers"
 require "cucumber"
+require "parallel_tests/gherkin/runner"
 
 require "ca_testing"
 


### PR DESCRIPTION
This adds a new patch for fixing parallel cucumber. In theory this might be a short lived patch as an identical patch has been submitted to the upstream repo.

In it we do four things.

- Capture the original cucumber options input
- Split the options into individual option "chunks"
- Re-stitch them all together as array item 1 (Everything but the retry flag), and array item 2 (The retry flag)
- Create the command in the same way as before, but glue the retry flag at the very end, so it works properly.