### PR TITLE
Feature/introduce halting versions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,5 +6,3 @@ AllCops:
   Exclude:
     # This patch is 80% copied code from the upstream repo. As such there are different style
     - 'lib/ca_testing/patches/parallel_cucumber.rb'
-    # This needs fixing in the gem proper
-    - 'vendor/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,23 @@
-## <sub>v2.2</sub>
+## <sub>main</sub>
 #### _Unreleased_
+
+**Breaking Changes**
+* Altered format / structure of patches to accept either...
+  * `#deprecation_notice_date` (Time) or `#deprecate_from` (Gem version)
+  * `#prevent_usage_date` (Time) or `#prevent_usage_from` (Gem version)
+
+**Removals**
+* Removed all Docker/Jenkins code as we now use GHA as our CI pipeline
+
+## <sub>v2.2</sub>
+#### _Aug. 12, 2021_
 
 **New**
 * Added Parallel Tests patch
   * The converted order of the command line options passed to cucumber was incorrect
 
 ## <sub>v2.1</sub>
-#### _Unreleased_
+#### _Jul. 26, 2021_
 
 **New**
 * Added extension for `Capybara::Node::Element#stale?`

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "citizens-advice-style", github: "citizensadvice/citizens-advice-style-ruby", tag: "v3.0.0"
+gem "citizens-advice-style", github: "citizensadvice/citizens-advice-style-ruby", tag: "v3.0.1"
 
 gemspec

--- a/lib/ca_testing/patches/base.rb
+++ b/lib/ca_testing/patches/base.rb
@@ -27,9 +27,9 @@ module CaTesting
       #
       def deprecate?
         if defined?(deprecation_notice_date)
-          Time.new > deprecation_notice_date
+          Time.new >= deprecation_notice_date
         elsif defined?(deprecate_from)
-          Gem::Version.new(gem_version) > Gem::Version.new(deprecate_from)
+          Gem::Version.new(gem_version) >= Gem::Version.new(deprecate_from)
         end
       end
 
@@ -42,9 +42,9 @@ module CaTesting
       #
       def prevent_usage?
         if defined?(prevent_usage_date)
-          Time.new > prevent_usage_date
+          Time.new >= prevent_usage_date
         elsif defined?(prevent_usage_from)
-          Gem::Version.new(gem_version) > Gem::Version.new(prevent_usage_from)
+          Gem::Version.new(gem_version) >= Gem::Version.new(prevent_usage_from)
         end
       end
     end

--- a/lib/ca_testing/patches/base.rb
+++ b/lib/ca_testing/patches/base.rb
@@ -18,8 +18,19 @@ module CaTesting
 
       private
 
+      #
+      # api private (Not intended to be instantiated directly!)
+      #
+      # From what point should this patch start throwing deprecation notices
+      # If a date is provided, then after that date
+      # If a version from is provided, then all releases after that one
+      # 
       def deprecate?
-        Time.new > deprecation_notice_date
+        if defined?(deprecation_notice_date)
+          Time.new > deprecation_notice_date
+        elsif defined?(deprecate_from)
+          Gem::Version.new(gem_version) > Gem::Version.new(deprecate_from)
+        end
       end
 
       def prevent_usage?

--- a/lib/ca_testing/patches/base.rb
+++ b/lib/ca_testing/patches/base.rb
@@ -23,8 +23,8 @@ module CaTesting
       #
       # From what point should this patch start throwing deprecation notices
       # If a date is provided, then after that date
-      # If a version from is provided, then all releases after that one
-      # 
+      # If a version from is provided, then all releases after that one (NB: You must provide a link to the gem version)
+      #
       def deprecate?
         if defined?(deprecation_notice_date)
           Time.new > deprecation_notice_date

--- a/lib/ca_testing/patches/base.rb
+++ b/lib/ca_testing/patches/base.rb
@@ -33,12 +33,19 @@ module CaTesting
         end
       end
 
+      #
+      # api private (Not intended to be instantiated directly!)
+      #
+      # From what point should this patch start preventing usage deprecation notices
+      # If a date is provided, then after that date
+      # If a version from is provided, then all releases after that one (NB: You must provide a link to the gem version)
+      #
       def prevent_usage?
-        Time.new > prevent_usage_date
-      end
-
-      def prevent_usage_date
-        Time.new(3000, 1, 1)
+        if defined?(prevent_usage_date)
+          Time.new > prevent_usage_date
+        elsif defined?(prevent_usage_from)
+          Gem::Version.new(gem_version) > Gem::Version.new(prevent_usage_from)
+        end
       end
     end
   end

--- a/lib/ca_testing/patches/capybara.rb
+++ b/lib/ca_testing/patches/capybara.rb
@@ -16,10 +16,6 @@ module CaTesting
       def perform
         ::Capybara::Node::Element.prepend SafariTextPatch
       end
-
-      def deprecate?
-        false
-      end
     end
 
     module SafariTextPatch

--- a/lib/ca_testing/patches/parallel_cucumber.rb
+++ b/lib/ca_testing/patches/parallel_cucumber.rb
@@ -21,8 +21,12 @@ module CaTesting
         Time.new(2022, 6, 30)
       end
 
-      def prevent_usage_date
-        Time.new(2022, 12, 25)
+      def prevent_usage_from
+        "4.0.0"
+      end
+
+      def gem_version
+        ::ParallelTests::VERSION
       end
     end
 

--- a/lib/ca_testing/patches/selenium_logger.rb
+++ b/lib/ca_testing/patches/selenium_logger.rb
@@ -19,10 +19,6 @@ module CaTesting
       def perform
         ::Selenium::WebDriver.logger.io.binmode
       end
-
-      def deprecate?
-        false
-      end
     end
   end
 end

--- a/lib/ca_testing/patches/selenium_manager.rb
+++ b/lib/ca_testing/patches/selenium_manager.rb
@@ -16,12 +16,12 @@ module CaTesting
         ::Selenium::WebDriver::Manager.prepend CookieConverter
       end
 
-      def deprecation_notice_date
-        Time.new(2021, 12, 25)
+      def deprecate?
+        Gem::Version.new(Selenium::WebDriver::VERSION) > Gem::Version.new("4.0.0.beta2")
       end
 
-      def prevent_usage_date
-        Time.new(2022, 6, 30)
+      def prevent_usage?
+        Gem::Version.new(Selenium::WebDriver::VERSION) > Gem::Version.new("4.0.0.beta4")
       end
     end
 

--- a/lib/ca_testing/patches/selenium_manager.rb
+++ b/lib/ca_testing/patches/selenium_manager.rb
@@ -25,7 +25,7 @@ module CaTesting
       end
 
       def gem_version
-        Selenium::WebDriver::VERSION
+        ::Selenium::WebDriver::VERSION
       end
     end
 

--- a/lib/ca_testing/patches/selenium_manager.rb
+++ b/lib/ca_testing/patches/selenium_manager.rb
@@ -20,12 +20,12 @@ module CaTesting
         "4.0.0.beta2"
       end
 
-      def gem_version
-        Selenium::WebDriver::VERSION
+      def prevent_usage_from
+        "4.0.0.beta4"
       end
 
-      def prevent_usage?
-        Gem::Version.new(Selenium::WebDriver::VERSION) > Gem::Version.new("4.0.0.beta4")
+      def gem_version
+        Selenium::WebDriver::VERSION
       end
     end
 

--- a/lib/ca_testing/patches/selenium_manager.rb
+++ b/lib/ca_testing/patches/selenium_manager.rb
@@ -16,8 +16,12 @@ module CaTesting
         ::Selenium::WebDriver::Manager.prepend CookieConverter
       end
 
-      def deprecate?
-        Gem::Version.new(Selenium::WebDriver::VERSION) > Gem::Version.new("4.0.0.beta2")
+      def deprecate_from
+        "4.0.0.beta2"
+      end
+
+      def gem_version
+        Selenium::WebDriver::VERSION
       end
 
       def prevent_usage?

--- a/lib/ca_testing/patches/selenium_manager.rb
+++ b/lib/ca_testing/patches/selenium_manager.rb
@@ -17,11 +17,11 @@ module CaTesting
       end
 
       def deprecate_from
-        "4.0.0.beta2"
+        "4.0.0.beta3"
       end
 
       def prevent_usage_from
-        "4.0.0.beta4"
+        "4.0.0.beta5"
       end
 
       def gem_version

--- a/lib/ca_testing/patches/selenium_options.rb
+++ b/lib/ca_testing/patches/selenium_options.rb
@@ -50,7 +50,7 @@ module CaTesting
       end
 
       def gem_version
-        Selenium::WebDriver::VERSION
+        ::Selenium::WebDriver::VERSION
       end
     end
 

--- a/lib/ca_testing/patches/selenium_options.rb
+++ b/lib/ca_testing/patches/selenium_options.rb
@@ -45,12 +45,12 @@ module CaTesting
         "4.0.0.beta4"
       end
 
-      def gem_version
-        Selenium::WebDriver::VERSION
+      def prevent_usage_from
+        "4.0.0"
       end
 
-      def prevent_usage?
-        Gem::Version.new(Selenium::WebDriver::VERSION) > Gem::Version.new("4.0.0")
+      def gem_version
+        Selenium::WebDriver::VERSION
       end
     end
 

--- a/lib/ca_testing/patches/selenium_options.rb
+++ b/lib/ca_testing/patches/selenium_options.rb
@@ -42,11 +42,11 @@ module CaTesting
       end
 
       def deprecate_from
-        "4.0.0.beta4"
+        "4.0.0.beta5"
       end
 
       def prevent_usage_from
-        "4.0.0"
+        "4.0.1"
       end
 
       def gem_version

--- a/lib/ca_testing/patches/selenium_options.rb
+++ b/lib/ca_testing/patches/selenium_options.rb
@@ -41,8 +41,12 @@ module CaTesting
         end
       end
 
-      def deprecate?
-        Gem::Version.new(Selenium::WebDriver::VERSION) > Gem::Version.new("4.0.0.beta4")
+      def deprecate_from
+        "4.0.0.beta4"
+      end
+
+      def gem_version
+        Selenium::WebDriver::VERSION
       end
 
       def prevent_usage?

--- a/lib/ca_testing/patches/selenium_options.rb
+++ b/lib/ca_testing/patches/selenium_options.rb
@@ -41,12 +41,12 @@ module CaTesting
         end
       end
 
-      def deprecation_notice_date
-        Time.new(2021, 12, 25)
+      def deprecate?
+        Gem::Version.new(Selenium::WebDriver::VERSION) > Gem::Version.new("4.0.0.beta4")
       end
 
-      def prevent_usage_date
-        Time.new(2022, 6, 30)
+      def prevent_usage?
+        Gem::Version.new(Selenium::WebDriver::VERSION) > Gem::Version.new("4.0.0")
       end
     end
 


### PR DESCRIPTION
This changes the way in which patches operate
- Now they can provide either a
  - date at which they deprecate / stop working
  - version at which they deprecate / stop working (They also need to provide a ref to the gem version here)