### PR TITLE
feature: Introduce Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,18 @@
   * `#deprecation_notice_date` (Time) or `#deprecate_from` (Gem version)
   * `#prevent_usage_date` (Time) or `#prevent_usage_from` (Gem version)
 
+* Rewrote public API of Browserstack Drivers
+  * Uses a similar `.for` notation to the remote API.
+  * Removes the need to provide the custom capabilities class (where it can be directly determined)
+
+* New (private) API for Capabilities which mirrors Options
+
 **Removals**
 * Removed all Docker/Jenkins code as we now use GHA as our CI pipeline
+
+**Changed**
+* Amalgamation / Standardisation down of tests and namespaces
+  * The previous v3 internet explorer namespace has been moved to v4 because it was actually a v4 driver
 
 ## <sub>v2.2</sub>
 #### _Aug. 12, 2021_

--- a/lib/ca_testing/drivers.rb
+++ b/lib/ca_testing/drivers.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require "selenium/webdriver/remote"
-
+require "ca_testing/drivers/browserstack"
 require "ca_testing/drivers/local"
 require "ca_testing/drivers/remote"
 require "ca_testing/drivers/v4"

--- a/lib/ca_testing/drivers/browserstack.rb
+++ b/lib/ca_testing/drivers/browserstack.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "ca_testing/drivers/v4/browserstack"
+
+module CaTesting
+  module Drivers
+    Browserstack = V4::Browserstack
+  end
+end

--- a/lib/ca_testing/drivers/v4.rb
+++ b/lib/ca_testing/drivers/v4.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "selenium/webdriver/remote"
-
 require "ca_testing/drivers/v4/local"
 require "ca_testing/drivers/v4/remote"
 require "ca_testing/drivers/v4/browserstack"

--- a/lib/ca_testing/drivers/v4.rb
+++ b/lib/ca_testing/drivers/v4.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
-require "ca_testing/drivers/v4/local"
-require "ca_testing/drivers/v4/remote"
 require "ca_testing/drivers/v4/browserstack"
+require "ca_testing/drivers/v4/capabilities"
+require "ca_testing/drivers/v4/local"
+require "ca_testing/drivers/v4/options"
+require "ca_testing/drivers/v4/remote"

--- a/lib/ca_testing/drivers/v4/browserstack.rb
+++ b/lib/ca_testing/drivers/v4/browserstack.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "faraday"
+require "selenium/webdriver/remote"
 
 require "ca_testing/drivers/v4/capabilities"
 require "ca_testing/drivers/v4/options"
@@ -75,7 +76,7 @@ module CaTesting
         end
 
         def browser_specific_capabilities
-          CaTesting::Drivers::V4::Capabilities.for(browser, device_options)
+          Capabilities.for(browser, device_options)
         end
 
         def browser_version_capability
@@ -85,7 +86,7 @@ module CaTesting
         end
 
         def options
-          CaTesting::Drivers::V4::Options.for(browser)
+          Options.for(browser)
         end
 
         def browserstack_hub_url

--- a/lib/ca_testing/drivers/v4/capabilities.rb
+++ b/lib/ca_testing/drivers/v4/capabilities.rb
@@ -30,10 +30,9 @@ module CaTesting
           def android_capabilities
             {
               "bstack:options" => {
-                "osVersion" => "10.0",
-                "deviceName" => "Samsung Galaxy S20",
+                "deviceName" => device_options[:device_name],
                 "realMobile" => "true",
-                "appiumVersion" => "1.17.0"
+                "appiumVersion" => ios_appium_version(device_options[:os_version])
               }
             }
           end
@@ -73,17 +72,24 @@ module CaTesting
               "bstack:options" => {
                 "deviceName" => device_options[:device_name],
                 "realMobile" => "true",
-                "appiumVersion" => appium_version(device_options[:ios_version])
+                "appiumVersion" => ios_appium_version(device_options[:os_version])
               }
             }
           end
 
-          def appium_version(ios_version)
+          def android_appium_version(android_version)
+            case android_version.to_f
+            when 10..; then "1.21.0"
+            when 9..;  then "1.20.2"
+            else raise ArgumentError, "Your Android Version is too low. Please don't use lower than Android Pie (9)."
+            end
+          end
+
+          def ios_appium_version(ios_version)
             case ios_version.to_f
-            when 14..15; then "1.20.3"
-            when 13..14; then "1.20.2"
-            when 12..13; then "1.19.1"
-            when 11..12; then "1.16.0"
+            when 13..; then "1.21.0"
+            when 12..; then "1.20.2"
+            when 11..; then "1.16.0"
             else raise ArgumentError, "Your iOS Version is too low. Please don't use lower than iOS 11."
             end
           end

--- a/lib/ca_testing/drivers/v4/capabilities.rb
+++ b/lib/ca_testing/drivers/v4/capabilities.rb
@@ -18,7 +18,7 @@ module CaTesting
 
           def capabilities_hash(browser, device_options)
             case browser
-            when :android;           then android_capabilities
+            when :android;           then android_capabilities(device_options)
             when :chrome;            then chrome_capabilities
             when :firefox;           then firefox_capabilities
             when :internet_explorer; then internet_explorer_capabilities
@@ -27,12 +27,12 @@ module CaTesting
             end
           end
 
-          def android_capabilities
+          def android_capabilities(device_options)
             {
               "bstack:options" => {
                 "deviceName" => device_options[:device_name],
                 "realMobile" => "true",
-                "appiumVersion" => ios_appium_version(device_options[:os_version])
+                "appiumVersion" => android_appium_version(device_options[:os_version])
               }
             }
           end

--- a/spec/ca_testing/drivers/browserstack_spec.rb
+++ b/spec/ca_testing/drivers/browserstack_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe CaTesting::Drivers::Browserstack do
+  it "aliases the shorter context to the V4 namespace" do
+    expect(described_class.new(double, double, double)).to be_a(CaTesting::Drivers::V4::Browserstack)
+  end
+end

--- a/spec/ca_testing/drivers/v4/capabilities_spec.rb
+++ b/spec/ca_testing/drivers/v4/capabilities_spec.rb
@@ -9,17 +9,28 @@ RSpec.describe CaTesting::Drivers::V4::Capabilities do
     context "for android" do
       let(:browser) { :android }
 
-      it "has correct android capabilities" do
-        expect(capabilities).to eq(
-          {
-            "bstack:options" => {
-              "osVersion" => "10.0",
-              "deviceName" => "Samsung Galaxy S20",
-              "realMobile" => "true",
-              "appiumVersion" => "1.17.0"
+      context "with a valid device / android version" do
+        let(:device_options) { { device_name: "SamsungGalaxyS20", os_version: "10" } }
+
+        it "has correct android capabilities" do
+          expect(capabilities).to eq(
+            {
+              "bstack:options" => {
+                "deviceName" => "SamsungGalaxyS20",
+                "realMobile" => "true",
+                "appiumVersion" => "1.21.0"
+              }
             }
-          }
-        )
+          )
+        end
+      end
+
+      context "with an invalid android version" do
+        let(:device_options) { { device_name: "SamsungGalaxyS20", os_version: "8" } }
+
+        it "it complains that the android version is invalid" do
+          expect { capabilities }.to raise_error(ArgumentError)
+        end
       end
     end
 
@@ -59,16 +70,17 @@ RSpec.describe CaTesting::Drivers::V4::Capabilities do
 
     context "for ios" do
       let(:browser) { :ios }
-      let(:device_options) { { device_name: "iPhone11", ios_version: "12" } }
 
       context "with a valid device / iOS version" do
-        it "has correct ios capabilities" do
+        let(:device_options) { { device_name: "iPhone11", os_version: "12" } }
+
+        it "has correct iOS capabilities" do
           expect(capabilities).to eq(
             {
               "bstack:options" => {
                 "deviceName" => "iPhone11",
                 "realMobile" => "true",
-                "appiumVersion" => "1.19.1"
+                "appiumVersion" => "1.20.2"
               }
             }
           )
@@ -76,7 +88,7 @@ RSpec.describe CaTesting::Drivers::V4::Capabilities do
       end
 
       context "with an invalid iOS version" do
-        let(:device_options) { { device_name: "iPhone11", ios_version: "10" } }
+        let(:device_options) { { device_name: "iPhone11", os_version: "10" } }
 
         it "it complains that the iOS version is invalid" do
           expect { capabilities }.to raise_error(ArgumentError)


### PR DESCRIPTION
We can now fully configure Android drivers and experiment in the same way

The following items have been checked off / tested
- Configuration using same key setup as ios
- Removal of spaces in names to make key passing nicer
- Testing of a variety of Samsung phones and android versions (9-11 only)

After merging this PR we probably should then cut the new major (v3), and look into integrating this into PW / Design System