### PR TITLE
Bugfix: Fix load issue for selenium webdriver Edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 **Bugfixes**
 * Fixed load error in Selenium Webdriver Edge
   * This issue was due to Selenium changing their path for Edge Options during the V4 betas
-
-
+  
 ## <sub>v3.0</sub>
 #### _Sep 02, 2021_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 #### _Unreleased_
 
 **Bugfixes**
-* Fixed load error in Selenium Webdrive Edge
+* Fixed load error in Selenium Webdriver Edge
+  * This issue was due to Selenium changing their path for Edge Options during the V4 betas
+
 
 ## <sub>v3.0</sub>
 #### _Sep 02, 2021_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 ## <sub>main</sub>
 #### _Unreleased_
 
-## <sub>v3.0</sub>
+## <sub>v3.0.1</sub>
 #### _Unreleased_
+
+**Bugfixes**
+* Fixed load error in Selenium Webdrive Edge
+
+## <sub>v3.0</sub>
+#### _Sep 02, 2021_
 
 **Breaking Changes**
 * Altered format / structure of patches to accept either...

--- a/lib/ca_testing/drivers/v4/options.rb
+++ b/lib/ca_testing/drivers/v4/options.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 require "selenium/webdriver/common/options"
-
 require "selenium/webdriver/chrome/options"
 require "selenium/webdriver/firefox/options"
-require "selenium/webdriver/edge/options"
 require "selenium/webdriver/safari/options"
+
+begin
+  require "selenium/webdriver/edge/options"
+rescue LoadError
+  require "selenium/webdriver/edge_chrome/options"
+end
 
 module CaTesting
   module Drivers
@@ -25,10 +29,19 @@ module CaTesting
             case browser
             when :chrome;             then ::Selenium::WebDriver::Chrome::Options.new
             when :firefox;            then ::Selenium::WebDriver::Firefox::Options.new(log_level: "trace")
-            when :edge;               then ::Selenium::WebDriver::Edge::Options.new
+            when :edge;               then edge_options
             when :safari;             then ::Selenium::WebDriver::Safari::Options.new(automatic_inspection: true)
             when :internet_explorer;  then internet_explorer_options
             else {}
+            end
+          end
+
+          # This is only needed before version 4.0 is stable
+          def edge_options
+            if defined? ::Selenium::WebDriver::EdgeChrome::Options
+              ::Selenium::WebDriver::EdgeChrome::Options.new
+            else
+              ::Selenium::WebDriver::Edge::Options.new
             end
           end
 

--- a/lib/ca_testing/drivers/v4/options.rb
+++ b/lib/ca_testing/drivers/v4/options.rb
@@ -5,6 +5,7 @@ require "selenium/webdriver/chrome/options"
 require "selenium/webdriver/firefox/options"
 require "selenium/webdriver/safari/options"
 
+# This is needed due to the paths being inconsistent during the v4 alphas/betas
 begin
   require "selenium/webdriver/edge/options"
 rescue LoadError

--- a/lib/ca_testing/version.rb
+++ b/lib/ca_testing/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CaTesting
-  VERSION = "3.0"
+  VERSION = "3.0.1"
 end


### PR DESCRIPTION
Problem found during the update of ca_testing gem 2.2 to 3.0 on Design System, related to multiple versions of Edge, EdgeHtml (old version Edge) and Edge Chrome (the current one).

<img width="1440" alt="Screenshot 2021-09-03 at 13 29 10 (1)" src="https://user-images.githubusercontent.com/11262774/132027061-cf8abaa9-2181-40d1-8e93-74a19a2728b7.png">
