### PR TITLE
Revert back to using out of the box default Edge settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,13 @@
 ## <sub>main</sub>
 #### _Unreleased_
 
+**Bugfixes**
+* Fix Load error in Edge Options
+  * Mac Edge was not properly processing the browser name by default
 
 **New**
 * Added testing for a matrix of ruby / selenium versions
   * Initially we're testing alpha/beta/latest versions of selenium against ruby 2.7 and 3.0
-## <sub>v3.0.1</sub>
-
-#### _Unreleased_
-**Bugfixes**
-* Fix Load error in Edge Options
-  * Mac Edge was not properly processing the browser name by default
 
 ## <sub>v3.0.1</sub>
 #### _Sep 07, 2021_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 ## <sub>main</sub>
 #### _Unreleased_
 
+
 **New**
 * Added testing for a matrix of ruby / selenium versions
   * Initially we're testing alpha/beta/latest versions of selenium against ruby 2.7 and 3.0
 ## <sub>v3.0.1</sub>
+
 #### _Unreleased_
+**Bugfixes**
+* Fixed load error in Selenium Webdriver Edge
+  * We can not use Microsoft Edge Beta for automation
+  * Revert back to using out of the box default Edge settings
+
+## <sub>v3.0.1</sub>
+#### _Sep 07, 2021_
 
 **Bugfixes**
 * Fixed load error in Selenium Webdriver Edge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@
 
 #### _Unreleased_
 **Bugfixes**
-* Fixed load error in Selenium Webdriver Edge
-  * We can not use Microsoft Edge Beta for automation
-  * Revert back to using out of the box default Edge settings
+* Fix Load error in Edge Options
+  * Mac Edge was not properly processing the browser name by default
 
 ## <sub>v3.0.1</sub>
 #### _Sep 07, 2021_

--- a/lib/ca_testing/drivers/v4/options.rb
+++ b/lib/ca_testing/drivers/v4/options.rb
@@ -1,16 +1,9 @@
 # frozen_string_literal: true
 
-require "selenium/webdriver/common/options"
-require "selenium/webdriver/chrome/options"
-require "selenium/webdriver/firefox/options"
-require "selenium/webdriver/safari/options"
-
-# This is needed due to the paths being inconsistent during the v4 alphas/betas
-begin
-  require "selenium/webdriver/edge/options"
-rescue LoadError
-  require "selenium/webdriver/edge_chrome/options"
-end
+require "selenium/webdriver/chrome"
+require "selenium/webdriver/firefox"
+require "selenium/webdriver/safari"
+require "selenium/webdriver/edge"
 
 module CaTesting
   module Drivers
@@ -30,19 +23,10 @@ module CaTesting
             case browser
             when :chrome;             then ::Selenium::WebDriver::Chrome::Options.new
             when :firefox;            then ::Selenium::WebDriver::Firefox::Options.new(log_level: "trace")
-            when :edge;               then edge_options
+            when :edge;               then ::Selenium::WebDriver::Edge::Options.new
             when :safari;             then ::Selenium::WebDriver::Safari::Options.new(automatic_inspection: true)
             when :internet_explorer;  then internet_explorer_options
             else {}
-            end
-          end
-
-          # This is only needed before version 4.0 is stable
-          def edge_options
-            if defined? ::Selenium::WebDriver::EdgeChrome::Options
-              ::Selenium::WebDriver::EdgeChrome::Options.new
-            else
-              ::Selenium::WebDriver::Edge::Options.new
             end
           end
 

--- a/lib/ca_testing/version.rb
+++ b/lib/ca_testing/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CaTesting
-  VERSION = "3.0.2"
+  VERSION = "3.0.1"
 end

--- a/lib/ca_testing/version.rb
+++ b/lib/ca_testing/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CaTesting
-  VERSION = "3.0.1"
+  VERSION = "3.0.2"
 end


### PR DESCRIPTION
This is a bugfix of the previous bugfix. The previous bugfix was not working properly when running tests local with Edge browser on Mac.

**Bugfixes**
* Fix Load error in Edge Options
  * Mac Edge was not properly processing the browser name by default