### PR TITLE
Add Edge tests for ca_testing gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 **New**
 * Added testing for a matrix of ruby / selenium versions
   * Initially we're testing alpha/beta/latest versions of selenium against ruby 2.7 and 3.0
+* Add Local Edge driver tests
+  * Previously, there weren't any tests for Edge driver
 
 ## <sub>v3.0.1</sub>
 #### _Sep 07, 2021_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 **New**
 * Added testing for a matrix of ruby / selenium versions
   * Initially we're testing alpha/beta/latest versions of selenium against ruby 2.7 and 3.0
-* Add Local Edge driver tests
+  
+* Added Local Edge driver tests
   * Previously, there weren't any tests for Edge driver
 
 ## <sub>v3.0.1</sub>

--- a/spec/ca_testing/drivers/v4/local_spec.rb
+++ b/spec/ca_testing/drivers/v4/local_spec.rb
@@ -118,13 +118,14 @@ RSpec.describe CaTesting::Drivers::V4::Local do
       end
 
       it "has correct browser options" do
+
         expect(options[:capabilities].last.as_json)
           .to eq(
-                {
-                  "browserName" => "MicrosoftEdge",
-                  "ms:edgeOptions" => {}
-                }
-              )
+            {
+              "browserName" => "MicrosoftEdge",
+              "ms:edgeOptions" => {}
+            }
+          )
       end
     end
   end

--- a/spec/ca_testing/drivers/v4/local_spec.rb
+++ b/spec/ca_testing/drivers/v4/local_spec.rb
@@ -105,5 +105,27 @@ RSpec.describe CaTesting::Drivers::V4::Local do
           )
       end
     end
+
+    context "for edge" do
+      let(:browser) { :edge }
+
+      it "has correct top level properties" do
+        expect(options.keys).to eq(standard_top_level_properties)
+      end
+
+      it "has correct desired capabilities" do
+        expect(options[:capabilities].first.as_json).to eq({})
+      end
+
+      it "has correct browser options" do
+        expect(options[:capabilities].last.as_json)
+          .to eq(
+                {
+                  "browserName" => "MicrosoftEdge",
+                  "ms:edgeOptions" => {}
+                }
+              )
+      end
+    end
   end
 end

--- a/spec/ca_testing/drivers/v4/local_spec.rb
+++ b/spec/ca_testing/drivers/v4/local_spec.rb
@@ -118,7 +118,6 @@ RSpec.describe CaTesting::Drivers::V4::Local do
       end
 
       it "has correct browser options" do
-
         expect(options[:capabilities].last.as_json)
           .to eq(
             {

--- a/spec/ca_testing/drivers/v4/options_spec.rb
+++ b/spec/ca_testing/drivers/v4/options_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe CaTesting::Drivers::V4::Options do
       it { is_expected.to have_attributes({ browser_name: "safari", automatic_inspection: true }) }
     end
 
+    context "for edge" do
+      let(:browser) { :edge }
+
+      it { is_expected.to have_attributes({ browser_name: "MicrosoftEdge" }) }
+    end
+
     context "when requesting a headless browser" do
       before { allow(described_class).to receive(:headless?) { true } }
 


### PR DESCRIPTION
I'm not a specialist in RSpec so I kind of went with the flow here. Let me know if there is anything missing or anything wrong or bizarre.

Add Edge tests in:
- driver/v4/local_spec.rb
- driver/v4/options.rb
