### PR TITLE
Release v3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## <sub>main</sub>
 #### _Unreleased_
 
+## <sub>v3.0.2</sub>
+#### _Unreleased_
+
 **New**
 * Added testing for a matrix of ruby / selenium versions
   * Initially we're testing alpha/beta/latest versions of selenium against ruby 2.7 and 3.0

--- a/lib/ca_testing/version.rb
+++ b/lib/ca_testing/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CaTesting
-  VERSION = "3.0.1"
+  VERSION = "3.0.2"
 end


### PR DESCRIPTION
**New**
* Added testing for a matrix of ruby / selenium versions
  * Initially we're testing alpha/beta/latest versions of selenium against ruby 2.7 and 3.0
  
* Added Local Edge driver tests
  * Previously, there weren't any tests for Edge driver

**Removals**
* As we're using GHA we don't need rake tasks anymore
  * `rake` is no longer a dev dependency

**Bugfixes**
* Fix Load error in Edge Options
  * Mac Edge was not properly processing the browser name by default