### PR TITLE
Driver registration fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,18 @@
   * Console Logging is now non-destructive and all logs when fetched are cached (To be later written to a file)
   * Console Logging can piped to a file or `$stdout` Using `#write_log_to_file`
 
+**Bugfixes**
+* Fix `require` errors in Driver registration process
+  * Some of the internal nested selenium code (Options / Capabilities e.t.c.), is not supported to be loaded
+  individually and instead should be loaded as a full package
+
 ## <sub>v3.0.2</sub>
 #### _Sep 20, 2021_
 
 **New**
 * Added testing for a matrix of ruby / selenium versions
   * Initially we're testing alpha/beta/latest versions of selenium against ruby 2.7 and 3.0
-  
+
 * Added Local Edge driver tests
   * Previously, there weren't any tests for Edge driver
 

--- a/lib/ca_testing/drivers/v4/browserstack.rb
+++ b/lib/ca_testing/drivers/v4/browserstack.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "faraday"
-require "selenium/webdriver/remote"
+require "selenium/webdriver"
 
 require "ca_testing/drivers/v4/capabilities"
 require "ca_testing/drivers/v4/options"

--- a/lib/ca_testing/drivers/v4/capabilities.rb
+++ b/lib/ca_testing/drivers/v4/capabilities.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "selenium/webdriver/remote"
+require "selenium/webdriver"
 
 module CaTesting
   module Drivers

--- a/lib/ca_testing/drivers/v4/local.rb
+++ b/lib/ca_testing/drivers/v4/local.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "selenium/webdriver/remote"
+require "selenium/webdriver"
 
 require "ca_testing/drivers/v4/options"
 

--- a/lib/ca_testing/drivers/v4/options.rb
+++ b/lib/ca_testing/drivers/v4/options.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require "selenium/webdriver/chrome"
-require "selenium/webdriver/firefox"
-require "selenium/webdriver/safari"
-require "selenium/webdriver/edge"
+require "selenium/webdriver"
 
 module CaTesting
   module Drivers

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "selenium-webdriver"
+require "selenium/webdriver"
 require "capybara"
 require "capybara/dsl"
 require "webdrivers"


### PR DESCRIPTION
After consultation with selenium upstream. They consider that there are too many "gaps" and "holes" that could be used when requiring sub-components of the driver (Such as options defaults e.t.c.)

As such they recommend only ever packaging the driver as a whole

Given we only want a portion, we just require the whole package to avoid any errors.